### PR TITLE
Feat: Add "Copy to..." and "Copy to folder again" options

### DIFF
--- a/Base.lproj/MainMenu.xib
+++ b/Base.lproj/MainMenu.xib
@@ -122,6 +122,18 @@
                                     <action selector="moveSelectedFilesAgain:" target="207" id="cVY-9b-EDj"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Copy To..." tag="14" id="e4f-92-7kq">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="copySelectedFiles:" target="207" id="a1b-45-7c2"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Copy To Folder Again" tag="15" keyEquivalent="c" id="b2k-58-4mj">
+                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                <connections>
+                                    <action selector="copySelectedFilesAgain:" target="207" id="e5p-33-1uv"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Move To Trash" tag="2" id="343">
                                 <string key="keyEquivalent" base64-UTF8="YES">
 CA

--- a/CreeveyController.h
+++ b/CreeveyController.h
@@ -45,6 +45,8 @@ NSDirectoryEnumerator *CreeveyEnumerator(NSString *path, BOOL recurseSubfolders)
 - (IBAction)setDesktopPicture:(id)sender;
 - (IBAction)moveSelectedFiles:(id)sender;
 - (IBAction)moveSelectedFilesAgain:(id)sender;
+- (IBAction)copySelectedFiles:(id)sender;
+- (IBAction)copySelectedFilesAgain:(id)sender;
 - (IBAction)moveToTrash:(id)sender;
 - (IBAction)transformJpeg:(id)sender;
 - (IBAction)sortThumbnails:(id)sender;

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -598,7 +598,6 @@ NSMutableAttributedString* Fileinfo2EXIFString(NSString *origPath, DYImageCache 
 	[self copySelectedFilesTo:dest];
 }
 
-
 // returns 1 if successful
 // unsuccessful: 0 user wants to continue; 2 cancel/abort
 - (char)trashFile:(NSString *)fullpath numLeft:(NSUInteger)numFiles resultingURL:(NSURL **)newURL {
@@ -966,6 +965,7 @@ enum {
 					return writable && YES;
 				}
 			}
+
 			isjpeg = slidesWindow.isMainWindow
 				? slidesWindow.currentFile && FileIsJPEG(slidesWindow.currentFile)
 				: numSelected > 0 && frontWindow && FilesContainJPEG(frontWindow.currentSelection);

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -239,6 +239,7 @@ NSMutableAttributedString* Fileinfo2EXIFString(NSString *origPath, DYImageCache 
 		[filetypes removeObject:type];
 	}
 	[self updateMoveToMenuItem];
+	[self updateCopyToMenuItem];
 	[self updateAlternateSlideshowMenuItem];
 	[self updateAppearance];
 	
@@ -484,6 +485,15 @@ NSMutableAttributedString* Fileinfo2EXIFString(NSString *origPath, DYImageCache 
 	item.title = [NSString stringWithFormat:NSLocalizedString(@"Move to “%@” Again", @"File menu"), name];
 }
 
+- (void)updateCopyToMenuItem {
+	NSString *path = [NSUserDefaults.standardUserDefaults stringForKey:@"lastUsedCopyToFolder"];
+	if (path == nil) return;
+	NSMenu *m = [NSApp.mainMenu itemWithTag:FILE_MENU].submenu;
+	NSMenuItem *item = [m itemWithTag:COPY_TO_AGAIN];
+	NSString *name = [NSFileManager.defaultManager displayNameAtPath:path];
+	item.title = [NSString stringWithFormat:NSLocalizedString(@"Copy to “%@” Again", @"File menu"), name];
+}
+
 - (void)updateAlternateSlideshowMenuItem {
 	NSMenu *m = [NSApp.mainMenu itemWithTag:SLIDESHOW_MENU].submenu;
 	NSMenuItem *item = [m itemWithTag:BEGIN_SLIDESHOW_ALTERNATE];
@@ -524,6 +534,36 @@ NSMutableAttributedString* Fileinfo2EXIFString(NSString *origPath, DYImageCache 
 	[creeveyWindows makeObjectsPerformSelector:@selector(filesWereUndeleted:) withObject:[moved valueForKey:@"path"]];
 }
 
+- (void)copySelectedFilesTo:(NSURL *)dest {
+	NSString *curr = slidesWindow.isMainWindow ? slidesWindow.basePath : frontWindow.path;
+	if ([dest isEqual:[NSURL fileURLWithPath:curr]]) return;
+
+	NSArray *files = slidesWindow.isMainWindow ? @[slidesWindow.currentFile] : frontWindow.currentSelection;
+	NSMutableArray<NSString*> *paths = [NSMutableArray array];
+	NSMutableArray<NSURL*> *copied = [NSMutableArray arrayWithCapacity:files.count];
+	NSMutableArray<NSString*> *notCopied = [NSMutableArray array];
+
+	NSError * __autoreleasing err;
+	for (NSString *f in files) {
+		NSURL *destUrl = [dest URLByAppendingPathComponent:f.lastPathComponent];
+		if ([NSFileManager.defaultManager copyItemAtPath:f toPath:destUrl.path error:&err]) {
+			[paths addObject:f];
+			[copied addObject:destUrl];
+		} else {
+			[notCopied addObject:f];
+		}
+	}
+	if (notCopied.count) {
+		NSAlert *alert = [[NSAlert alloc] init];
+		if (notCopied.count == 1) {
+			alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"The file “%@” could not be copied because of an error: %@", @""), notCopied[0].lastPathComponent, err.localizedDescription];
+		} else {
+			alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"%lu files could not be copied because of an error.",@""), notCopied.count];
+		}
+		[alert runModal];
+	}
+}
+
 - (IBAction)moveSelectedFiles:(id)sender {
 	NSOpenPanel *op = [NSOpenPanel openPanel];
 	op.canChooseFiles = NO;
@@ -540,6 +580,24 @@ NSMutableAttributedString* Fileinfo2EXIFString(NSString *origPath, DYImageCache 
 	NSURL *dest = [NSURL fileURLWithPath:folder isDirectory:YES];
 	[self moveSelectedFilesTo:dest];
 }
+
+- (IBAction)copySelectedFiles:(id)sender {
+	NSOpenPanel *op = [NSOpenPanel openPanel];
+	op.canChooseFiles = NO;
+	op.canChooseDirectories = YES;
+	if ([op runModal] != NSModalResponseOK) return;
+	NSURL *dest = op.URL;
+	[self copySelectedFilesTo:dest];
+	[NSUserDefaults.standardUserDefaults setObject:dest.path forKey:@"lastUsedCopyToFolder"];
+	[self updateCopyToMenuItem];
+}
+
+- (IBAction)copySelectedFilesAgain:(id)sender {
+	NSString *folder = [NSUserDefaults.standardUserDefaults stringForKey:@"lastUsedCopyToFolder"];
+	NSURL *dest = [NSURL fileURLWithPath:folder isDirectory:YES];
+	[self copySelectedFilesTo:dest];
+}
+
 
 // returns 1 if successful
 // unsuccessful: 0 user wants to continue; 2 cancel/abort
@@ -838,6 +896,8 @@ enum {
 	BEGIN_SLIDESHOW_ALTERNATE,
 	MOVE_TO,
 	MOVE_TO_AGAIN,
+	COPY_TO,
+	COPY_TO_AGAIN,
 	JPEG_OP = 100,
 	ROTATE_L = 107,
 	ROTATE_R = 105,
@@ -875,6 +935,7 @@ enum {
 	NSUInteger numSelected = frontWindow ? frontWindow.selectedIndexes.count : 0;
 	BOOL writable, isjpeg;
 	NSString *moveTo;
+	NSString *copyTo;
 	
 	switch (test_t) {
 		case NEW_TAB:
@@ -883,6 +944,9 @@ enum {
 			moveTo = [NSUserDefaults.standardUserDefaults stringForKey:@"lastUsedMoveToFolder"];
 			// fall through
 		case MOVE_TO:
+		case COPY_TO_AGAIN:
+			copyTo = [NSUserDefaults.standardUserDefaults stringForKey:@"lastUsedCopyToFolder"];
+		case COPY_TO:
 		case MOVE_TO_TRASH:
 		case JPEG_OP:
 			// only when slides isn't loading cache!
@@ -893,8 +957,15 @@ enum {
 					[NSFileManager.defaultManager isDeletableFileAtPath:
 					 slidesWindow.currentFile]
 				: numSelected > 0 && frontWindow && frontWindow.currentFilesDeletable;
-			if (t != JPEG_OP) return writable && (t == MOVE_TO_AGAIN ? moveTo != nil : YES);
-			
+			if (t != JPEG_OP) {
+				if (t == MOVE_TO_AGAIN) {
+					return writable && moveTo != nil;
+				} else if (t == COPY_TO_AGAIN) {
+					return writable && copyTo != nil;
+				} else {
+					return writable && YES;
+				}
+			}
 			isjpeg = slidesWindow.isMainWindow
 				? slidesWindow.currentFile && FileIsJPEG(slidesWindow.currentFile)
 				: numSelected > 0 && frontWindow && FilesContainJPEG(frontWindow.currentSelection);

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -349,6 +349,9 @@
         }
       }
     },
+    "%lu files could not be copied because of an error." : {
+
+    },
     "%lu files could not be moved because of an error." : {
       "localizations" : {
         "de" : {
@@ -907,6 +910,9 @@
           }
         }
       }
+    },
+    "Copy to “%@” Again" : {
+      "comment" : "File menu"
     },
     "Could not check for update - an error occurred while connecting to the server." : {
       "localizations" : {
@@ -2052,6 +2058,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在排列 %lu 個檔案名稱⋯⋯"
+          }
+        }
+      }
+    },
+    "The file “%@” could not be copied because of an error: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The file “%1$@” could not be copied because of an error: %2$@"
           }
         }
       }

--- a/mul.lproj/MainMenu.xcstrings
+++ b/mul.lproj/MainMenu.xcstrings
@@ -3847,6 +3847,18 @@
         }
       }
     },
+    "b2k-58-4mj.title" : {
+      "comment" : "Class = \"NSMenuItem\"; title = \"Copy To Folder Again\"; ObjectID = \"b2k-58-4mj\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Copy To Folder Again"
+          }
+        }
+      }
+    },
     "c0g-qO-OVm.title" : {
       "comment" : "Class = \"NSMenuItem\"; title = \"Move To Folder Again\"; ObjectID = \"c0g-qO-OVm\";",
       "extractionState" : "extracted_with_value",
@@ -3885,6 +3897,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "再次搬移"
+          }
+        }
+      }
+    },
+    "e4f-92-7kq.title" : {
+      "comment" : "Class = \"NSMenuItem\"; title = \"Copy To...\"; ObjectID = \"e4f-92-7kq\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Copy To..."
           }
         }
       }


### PR DESCRIPTION
As described in #79 . Option in menys (with shortcut ctrl+cmd+c) to copy current file to a specified folder. Useful when filtering images and wanting to have an unfiltered folder and copy good/selecetd images to a "filtered" folder.

Currently implemented so that "moveto" and "copyto" have separate destinations.

I am very unfamiliar with objective-c/xcode and basically copied most of the functions etc from the `moveTo...` functionality. Will be very happy to update/fix/work on it from a review/feedback. :)