### PR TITLE
Fix fullscreen macos26 grey border fullscreen

### DIFF
--- a/DYImageView.m
+++ b/DYImageView.m
@@ -54,11 +54,11 @@
 }
 
 - (void)drawRect:(NSRect)rect {
-    // Always fill full bounds black first
+    // Always paint a black canvas first
     [NSColor.blackColor set];
     NSRectFill(self.bounds);
 
-    if (!image) return; // Nothing else to draw
+    if (!image) return;
 
 	NSRect srcRect, destinationRect;
 	float zoom = zoomF;
@@ -125,6 +125,7 @@
 		destinationRect = [self convertRect:destinationRect fromView:nil];
 		[NSBezierPath fillRect:destinationRect];
 	}
+    destinationRect = NSIntegralRect(destinationRect);
 	NSGraphicsContext *cg = NSGraphicsContext.currentContext;
 	NSImageInterpolation oldInterp = cg.imageInterpolation;
 	cg.imageInterpolation = zoom >= 4 ? NSImageInterpolationNone : NSImageInterpolationHigh;
@@ -163,7 +164,7 @@
 }
 
 - (BOOL)isOpaque {
-	return YES;
+    return YES; // matches full-bounds black fill
 }
 
 - (void)animateGIF:(NSTimer *)t {

--- a/DYImageView.m
+++ b/DYImageView.m
@@ -54,8 +54,12 @@
 }
 
 - (void)drawRect:(NSRect)rect {
-	if (!image) return; //don't draw if nil
-	
+    // Always fill full bounds black first
+    [NSColor.blackColor set];
+    NSRectFill(self.bounds);
+
+    if (!image) return; // Nothing else to draw
+
 	NSRect srcRect, destinationRect;
 	float zoom = zoomF;
 	NSRect boundsRect = [self convertRect:self.bounds toView:nil];
@@ -156,6 +160,10 @@
 			gifTimer.tolerance = frameDuration*0.15;
 		}
 	}
+}
+
+- (BOOL)isOpaque {
+	return YES;
 }
 
 - (void)animateGIF:(NSTimer *)t {

--- a/SlideshowWindow.m
+++ b/SlideshowWindow.m
@@ -99,7 +99,7 @@ static BOOL UsingMagicMouse(NSEvent *e) {
 		_upcomingQueue = [[NSOperationQueue alloc] init];
 		_fileWatcher = [[DYFileWatcher alloc] initWithDelegate:self];
 		
-			self.backgroundColor = NSColor.blackColor;
+		self.backgroundColor = NSColor.blackColor;
 		self.opaque = YES;
 		_fullscreenMode = YES; // set this to prevent autosaving the frame from the nib
 		self.hasShadow = NO;
@@ -108,7 +108,7 @@ static BOOL UsingMagicMouse(NSEvent *e) {
 		self.collectionBehavior = NSWindowCollectionBehaviorParticipatesInCycle|NSWindowCollectionBehaviorFullScreenNone|NSWindowCollectionBehaviorMoveToActiveSpace;
 		// *** Unfortunately the menubar doesn't seem to show up on the second screen... Eventually we'll want to switch to use NSView's enterFullScreenMode:withOptions:
 		currentIndex = NSNotFound;
-	  }
+	}
     return self;
 }
 


### PR DESCRIPTION
fixes https://github.com/gobbledegook/creevey/issues/82 by handling the fullscreen window in a special way for macOS 26 Tahoe. I could not test it with older macOS but it should cause no problems (that needs testing).

Short Summary
- Fix grey border on fullscreen on macOS 26 by ensuring a fully opaque, black canvas at all times
- Image view now paints black before any image and is declared opaque for avoiding grey window borders
- Fullscreen uses constraint-based layout; windowed uses autoresizing; no mixing of layout systems (could not get the new fullscreen handling to work in window mode)
- Overhauled window config:
  - fullscreen is borderless, opaque, no shadow, hidden title
  - windowed is titled, opaque, with shadow
- Notch/safe-area handled in fullscreen by offsetting the top constraint
- Centralized screen configuration; avoid manually setting view frames when constraints are active