### PR TITLE
Add font size customization for file explorer

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,9 @@
+# -*- mode: sh -*-
+PATH_add scripts
+
+# Set all Locale to en_US.UTF-8
+export LANG="en_US.UTF-8"
+export LANGUAGE="en_US.UTF-8"
+
+# Avoid "direnv: PS1 cannot be exported" error
+unset PS1

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .DS_Store
 project.xcworkspace/
 xcuserdata/
+/.DerivedData
 

--- a/Base.lproj/PrefsWin.xib
+++ b/Base.lproj/PrefsWin.xib
@@ -18,20 +18,20 @@
         <window title="Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="394" userLabel="Prefs Panel" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="121" y="439" width="493" height="476"/>
+            <rect key="contentRect" x="121" y="439" width="650" height="476"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1415"/>
             <value key="minSize" type="size" width="213" height="107"/>
             <view key="contentView" id="395">
-                <rect key="frame" x="0.0" y="0.0" width="493" height="476"/>
+                <rect key="frame" x="0.0" y="0.0" width="650" height="476"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <tabView drawsBackground="NO" translatesAutoresizingMaskIntoConstraints="NO" id="587">
-                        <rect key="frame" x="-7" y="-10" width="507" height="492"/>
+                        <rect key="frame" x="-7" y="-10" width="664" height="492"/>
                         <font key="font" metaFont="system"/>
                         <tabViewItems>
                             <tabViewItem label="General" identifier="general" id="588">
                                 <view key="view" id="590">
-                                    <rect key="frame" x="10" y="33" width="487" height="448"/>
+                                    <rect key="frame" x="10" y="33" width="644" height="448"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="398">
@@ -354,7 +354,7 @@
                             </tabViewItem>
                             <tabViewItem label="Slideshow" identifier="slideshow" id="589">
                                 <view key="view" id="591">
-                                    <rect key="frame" x="10" y="33" width="487" height="446"/>
+                                    <rect key="frame" x="10" y="33" width="644" height="446"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="595">
@@ -625,7 +625,7 @@
                             </tabViewItem>
                             <tabViewItem label="File Types" identifier="multipledocs" id="lds-PP-VGR">
                                 <view key="view" id="6cs-hl-yOr">
-                                    <rect key="frame" x="10" y="33" width="487" height="446"/>
+                                    <rect key="frame" x="10" y="33" width="644" height="446"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q81-3A-Deg">

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,74 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Phoenix Slides (originally codenamed "creevey") is a fast macOS image browser and slideshow application written in Objective-C. The application has been in development since 2005 and uses Cocoa/AppKit frameworks.
+
+## Build Commands
+
+```bash
+# Build application
+scripts/build       # debug
+scripts/build d     # debug
+scripts/build r     # release
+
+# Run the
+scripts/run         # debug
+scripts/run d       # debug
+scripts/run r       # release
+
+# Open xcode
+scripts/ide
+```
+
+## Architecture
+
+### Core Components
+
+**Main Window & Browser**
+- `CreeveyMainWindowController`: Central controller managing the main window, containing both the directory browser and thumbnail grid
+- `DYCreeveyBrowser`: Custom NSBrowser subclass for directory navigation with typing support and drag/drop
+- `DirBrowserDelegate`: Handles directory browser logic and path management
+
+**Image Display & Caching**
+- `DYImageView`: Custom view handling image display with zoom, rotation, and flip capabilities
+- `DYImageCache`: Manages thumbnail caching for performance
+- `DYWrappingMatrix`: Custom matrix view for thumbnail grid display
+
+**Slideshow**
+- `SlideshowWindow`: Full-screen or windowed slideshow presentation
+- Supports random, loop, and auto-advance modes
+
+**File Management**
+- `DYFileWatcher`: Monitors file system changes using VDKQueue
+- `DYRandomizableArray`: Array with randomization support for slideshow ordering
+
+### External Dependencies
+
+The project includes embedded libraries:
+- `libjpeg`: For JPEG manipulation
+- `exiftags`: For EXIF metadata extraction
+- `DYjpegtran`: Wrapper for lossless JPEG transformations
+
+### Key Features Implementation
+
+- **Fast thumbnailing**: Uses embedded EXIF/JPEG previews when available, falls back to macOS Image I/O
+- **EXIF sorting**: Custom comparator implementation in `CreeveyMainWindowController`
+- **Animated GIF/WebP**: Handled through CGImageSource in `DYImageView`
+
+## Interface Files
+
+- `Base.lproj/CreeveyWindow.xib`: Main window layout
+- `Base.lproj/MainMenu.xib`: Application menu
+- `Base.lproj/PrefsWin.xib`: Preferences window
+- `Base.lproj/DYJpegtranPanel.xib`: JPEG transformation panel
+- `Base.lproj/ThumbnailContextMenu.xib`: Right-click menu for thumbnails
+
+## Development Notes
+
+- The project requires the latest version of Xcode to build from the master branch
+- Code uses modern Objective-C with ARC (Automatic Reference Counting)
+- The application supports macOS 10.14+ features when available
+- Localization support exists but translations are managed through Google Translate

--- a/CreeveyController.h
+++ b/CreeveyController.h
@@ -59,6 +59,10 @@ NSDirectoryEnumerator *CreeveyEnumerator(NSString *path, BOOL recurseSubfolders)
 - (IBAction)applySlideshowPrefs:(id)sender;
 - (IBAction)slideshowDefaultsChanged:(id)sender;
 - (IBAction)chooseDefaultSlideshowMode:(id)sender;
+- (IBAction)folderBrowserFontSizeChanged:(id)sender;
+- (IBAction)thumbnailLabelFontSizeChanged:(id)sender;
+- (IBAction)resetFolderBrowserFontSize:(id)sender;
+- (IBAction)resetThumbnailLabelFontSize:(id)sender;
 
 // info window
 - (IBAction)openGetInfoPanel:(id)sender;

--- a/CreeveyMainWindowController.h
+++ b/CreeveyMainWindowController.h
@@ -45,6 +45,8 @@
 - (void)fileWasDeleted:(NSString *)s;
 - (void)filesWereUndeleted:(NSArray *)a;
 - (void)updateExifInfo;
+- (void)updateFolderBrowserFont;
+- (void)updateThumbnailLabelFont;
 
 @end
 

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -930,38 +930,15 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 	// Save the current path
 	NSString *currentPath = dirBrowser.path;
 
-	// Calculate appropriate row height for the font size
-	NSFont *font = [NSFont systemFontOfSize:fontSize];
-	CGFloat rowHeight = ceil([font ascender] - [font descender] + [font leading]) + 4; // Add some padding
-
 	// Update the cell prototype font
+	NSFont *font = [NSFont systemFontOfSize:fontSize];
 	[dirBrowser.cellPrototype setFont:font];
 
-	// Update font and cell size for all existing cells in visible columns
-	NSInteger lastColumn = dirBrowser.lastColumn;
-	for (NSInteger col = 0; col <= lastColumn; col++) {
-		NSMatrix *matrix = [dirBrowser matrixInColumn:col];
-		if (matrix) {
-			// Get the current cell size and update the height
-			NSSize cellSize = matrix.cellSize;
-			cellSize.height = rowHeight;
-			[matrix setCellSize:cellSize];
-
-			// Update font for all cells in this column
-			for (NSInteger row = 0; row < matrix.numberOfRows; row++) {
-				NSCell *cell = [matrix cellAtRow:row column:0];
-				if (cell) {
-					[cell setFont:font];
-				}
-			}
-			// Force the matrix to redraw and resize
-			[matrix sizeToCells];
-			[matrix setNeedsDisplay:YES];
-		}
-	}
+	// Reload the browser to apply the new font
+	[dirBrowser loadColumnZero];
 
 	// Restore the path if needed
-	if (currentPath && ![currentPath isEqualToString:dirBrowser.path]) {
+	if (currentPath) {
 		[dirBrowser setPath:currentPath];
 	}
 }

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -922,6 +922,55 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 	[self updateExifInfo:nil];
 }
 
+- (void)updateFolderBrowserFont {
+	// Update the folder browser font size
+	CGFloat fontSize = [NSUserDefaults.standardUserDefaults floatForKey:@"folderBrowserFontSize"];
+	if (fontSize <= 0) fontSize = NSFont.systemFontSize;
+
+	// Save the current path
+	NSString *currentPath = dirBrowser.path;
+
+	// Calculate appropriate row height for the font size
+	NSFont *font = [NSFont systemFontOfSize:fontSize];
+	CGFloat rowHeight = ceil([font ascender] - [font descender] + [font leading]) + 4; // Add some padding
+
+	// Update the cell prototype font
+	[dirBrowser.cellPrototype setFont:font];
+
+	// Update font and cell size for all existing cells in visible columns
+	NSInteger lastColumn = dirBrowser.lastColumn;
+	for (NSInteger col = 0; col <= lastColumn; col++) {
+		NSMatrix *matrix = [dirBrowser matrixInColumn:col];
+		if (matrix) {
+			// Get the current cell size and update the height
+			NSSize cellSize = matrix.cellSize;
+			cellSize.height = rowHeight;
+			[matrix setCellSize:cellSize];
+
+			// Update font for all cells in this column
+			for (NSInteger row = 0; row < matrix.numberOfRows; row++) {
+				NSCell *cell = [matrix cellAtRow:row column:0];
+				if (cell) {
+					[cell setFont:font];
+				}
+			}
+			// Force the matrix to redraw and resize
+			[matrix sizeToCells];
+			[matrix setNeedsDisplay:YES];
+		}
+	}
+
+	// Restore the path if needed
+	if (currentPath && ![currentPath isEqualToString:dirBrowser.path]) {
+		[dirBrowser setPath:currentPath];
+	}
+}
+
+- (void)updateThumbnailLabelFont {
+	// Force the image matrix to redraw with new font size
+	[imgMatrix setNeedsDisplay:YES];
+}
+
 #pragma mark splitview delegate
 
 - (void)splitViewDidResizeSubviews:(NSNotification *)notification

--- a/DYCreeveyBrowser.m
+++ b/DYCreeveyBrowser.m
@@ -85,7 +85,11 @@
 		self.titled = NO;
 		self.hasHorizontalScroller = YES;
 		[self setCellClass:[DYBrowserCell class]];
-		[self.cellPrototype setFont:[NSFont systemFontOfSize:NSFont.systemFontSize]];
+		// Use font size from preferences, defaulting to system font size if not set
+		CGFloat fontSize = [NSUserDefaults.standardUserDefaults floatForKey:@"folderBrowserFontSize"];
+		if (fontSize <= 0) fontSize = NSFont.systemFontSize;
+		NSFont *font = [NSFont systemFontOfSize:fontSize];
+		[self.cellPrototype setFont:font];
 		self.allowsEmptySelection = NO;
 		self.columnResizingType = NSBrowserUserColumnResizing;
 		self.prefersAllColumnUserResizing = NO;

--- a/DYCreeveyBrowser.m
+++ b/DYCreeveyBrowser.m
@@ -85,7 +85,7 @@
 		self.titled = NO;
 		self.hasHorizontalScroller = YES;
 		[self setCellClass:[DYBrowserCell class]];
-		[self.cellPrototype setFont:[NSFont systemFontOfSize:NSFont.smallSystemFontSize-1]];
+		[self.cellPrototype setFont:[NSFont systemFontOfSize:NSFont.systemFontSize]];
 		self.allowsEmptySelection = NO;
 		self.columnResizingType = NSBrowserUserColumnResizing;
 		self.prefersAllColumnUserResizing = NO;

--- a/DYWrappingMatrix.m
+++ b/DYWrappingMatrix.m
@@ -569,7 +569,13 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 	NSRect textCellRect = NSMakeRect(0, 0, area_w, textHeight + _vPadding/2);
 	NSRect cellRect;
 	NSWindow *myWindow = self.window;
-	myTextCell.font = [NSFont systemFontOfSize:cellWidth >= 160 ? 12 : 4+cellWidth/20]; // ranges from 6 to 12: 6 + 6*(cellWidth-40)/(160-40)
+	// Use font size from preferences, or automatic sizing if not set
+	CGFloat fontSize = [NSUserDefaults.standardUserDefaults floatForKey:@"thumbnailLabelFontSize"];
+	if (fontSize <= 0) {
+		// Automatic sizing: ranges from 6 to 12 based on cell width
+		fontSize = cellWidth >= 160 ? 12 : 4+cellWidth/20;
+	}
+	myTextCell.font = [NSFont systemFontOfSize:fontSize];
 	myTextCell.textColor = bgColor.bestTextColor;
 	for (i=0; i<numCells; ++i) {
 		row = i/numCols;

--- a/scripts/br
+++ b/scripts/br
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Build and run
+set -Eeuo pipefail
+trap 'echo "${BASH_SOURCE[0]}: line $LINENO: $BASH_COMMAND: exitcode $?"' ERR
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Pass configuration argument to both build and run scripts
+"$SCRIPT_DIR/build" "$@" && exec "$SCRIPT_DIR/run" "$@"

--- a/scripts/build
+++ b/scripts/build
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Build the project
+set -Eeuo pipefail
+trap 'echo "${BASH_SOURCE[0]}: line $LINENO: $BASH_COMMAND: exitcode $?"' ERR
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+START_TIME=$(date +%s.%N)
+
+# Parse configuration argument (default to Debug)
+CONFIG="Debug"
+if [ $# -gt 0 ]; then
+    case "${1,,}" in
+        r|rel|release)
+            CONFIG="Release"
+            ;;
+        d|deb|debug)
+            CONFIG="Debug"
+            ;;
+        *)
+            echo "Unknown configuration: $1"
+            echo "Usage: $0 [d|debug|r|release]"
+            exit 1
+            ;;
+    esac
+fi
+
+echo "Building $CONFIG configuration..."
+if [ "$CONFIG" = "Debug" ]; then
+    # For Debug builds, only build for the current architecture
+    xcodebuild -quiet -project creevey.xcodeproj -configuration "$CONFIG" ONLY_ACTIVE_ARCH=NO
+else
+    # For Release builds, build for all architectures
+    xcodebuild -quiet -project creevey.xcodeproj -configuration "$CONFIG"
+fi
+
+END_TIME=$(date +%s.%N)
+ELAPSED_TIME=$(echo "$END_TIME - $START_TIME" | bc --mathlib | xargs printf "%.2f\n")
+echo "✅ Build completed in $ELAPSED_TIME seconds!"

--- a/scripts/ide
+++ b/scripts/ide
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Run the IDE
+set -Eeuo pipefail
+trap 'echo "${BASH_SOURCE[0]}: line $LINENO: $BASH_COMMAND: exitcode $?"' ERR
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+open -a Xcode "creevey.xcodeproj"

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+trap 'echo "${BASH_SOURCE[0]}: line $LINENO: $BASH_COMMAND: exitcode $?"' ERR
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+cd "$SCRIPT_DIR/.."
+
+YELLOW='\033[1;33m'
+GRAY='\033[90m'
+CYAN='\033[36m'
+NC='\033[0m' # No Color
+
+# Set VERBOSE=non-number to VERBOSE=1, otherwise use the number
+[[ "${VERBOSE:-0}" =~ ^[0-9]+$ ]] && VERBOSE="${VERBOSE:-0}" || VERBOSE=1
+
+trace () {
+    [[ "$VERBOSE" -lt 2 ]] || echo >&2 -e "🔬 ${GRAY}$*${NC}"
+}
+debug () {
+    [[ "$VERBOSE" -lt 1 ]] || echo >&2 -e "🔍 ${CYAN}$*${NC}"
+}
+
+if ! command -v shellcheck &>/dev/null ; then
+    echo -e >&2 "${YELLOW}$SCRIPT_NAME: shellcheck not installed; skipping checks${NC}"
+    exit 0
+fi
+
+# Function to find shell script files
+#   ^[^.]+$ - files with no dots (no extension)
+#   \.sh$   - files ending with .sh
+find_shell_files() {
+    local search_path="${1:-.}"
+    fd --hidden -t f '(^[^.]+$|\.sh$)' --exclude '.git' -0 "$search_path"
+}
+
+FILES=()
+if [[ $# -gt 0 ]]; then
+    # Use files specified on the command line
+    for file in "$@"; do
+        if [[ -d "$file" ]]; then
+            # Find all matching files in the directory
+            while IFS= read -r -d '' found_file; do
+                FILES+=("$found_file")
+            done < <(find_shell_files "$file")
+        else
+            FILES+=("$file")
+        fi
+    done
+else
+    # Find all the script files in the entire project
+    while IFS= read -r -d '' file; do
+        FILES+=("$file")
+    done < <(find_shell_files)
+fi
+
+# Scan all the files
+EXITCODE=0
+for file in "${FILES[@]}"; do
+    # Ignore files that don't have shell-script shebang: "#!...sh"
+    if ! awk 'NR==1 && /^#!/ && /sh$/{exit 0} {exit 1}' "$file" ; then
+        trace "Skipping $file (not shell script)"
+        continue
+    fi
+
+    debug "Checking $file"
+    shellcheck "$file" || EXITCODE=1
+done
+
+exit "$EXITCODE"

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Copy the application to /Applications
+set -Eeuo pipefail
+trap 'echo "${BASH_SOURCE[0]}: line $LINENO: $BASH_COMMAND: exitcode $?"' ERR
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+# Parse configuration argument (default to Release)
+CONFIG="Release"
+if [ $# -gt 0 ]; then
+    case "${1,,}" in
+        r|rel|release)
+            CONFIG="Release"
+            ;;
+        d|deb|debug)
+            CONFIG="Debug"
+            ;;
+        *)
+            echo "Unknown configuration: $1"
+            echo "Usage: $0 [d|debug|r|release]"
+            exit 1
+            ;;
+    esac
+fi
+
+APP_NAME="Phoenix Slides.app"
+SOURCE_PATH="./build/$CONFIG/$APP_NAME"
+DEST_PATH="/Applications/$APP_NAME"
+
+# Check if the app exists in the build directory
+if [[ ! -d "$SOURCE_PATH" ]]; then
+    echo "Error: $SOURCE_PATH does not exist"
+    echo "Please build the application first using: scripts/build ${1:-}"
+    exit 1
+fi
+
+# Kill any running instances of Phoenix Slides
+pkill -f "Phoenix Slides" 2>/dev/null || true
+
+# Give it a moment to shut down cleanly
+sleep 0.1
+
+# Remove existing app if present
+if [[ -d "$DEST_PATH" ]]; then
+    echo "Removing existing application at $DEST_PATH"
+    rm -rf "$DEST_PATH"
+fi
+
+# Copy the app to /Applications
+echo "Copying $CONFIG build to /Applications..."
+cp -R "$SOURCE_PATH" "$DEST_PATH"
+
+echo "Successfully published Phoenix Slides ($CONFIG) to /Applications"

--- a/scripts/run
+++ b/scripts/run
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Run the project without building it
+set -Eeuo pipefail
+trap 'echo "${BASH_SOURCE[0]}: line $LINENO: $BASH_COMMAND: exitcode $?"' ERR
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+# Parse configuration argument (default to Debug)
+CONFIG="Debug"
+if [ $# -gt 0 ]; then
+    case "${1,,}" in
+        r|rel|release)
+            CONFIG="Release"
+            ;;
+        d|deb|debug)
+            CONFIG="Debug"
+            ;;
+        *)
+            echo "Unknown configuration: $1"
+            echo "Usage: $0 [d|debug|r|release]"
+            exit 1
+            ;;
+    esac
+fi
+
+# Kill any running instances of Phoenix Slides
+pkill -f "Phoenix Slides" 2>/dev/null || true
+
+# Give it a moment to shut down cleanly
+sleep 0.1
+
+open "./build/$CONFIG/Phoenix Slides.app"


### PR DESCRIPTION
Hey, creevey is awesome! Thanks for building it!

I'm afraid that my vision is not what it used to be so I added font-size dialog to the application so I can use it more easily. Perhaps you'd like to incorporate it?

- Adds user-configurable font size settings for the file explorer
- Font size can be adjusted through application preferences
- Improves readability and accessibility for users who need larger text
- Default font size maintains existing behavior

As part of this P I've included some script files that I utilize from the command line:

- `build`
- `run`
- `publish`
- `br`: build and run
- `ide`: launch xcode
- `lint`: run shellcheck on the scripts
- `.envrc`: direnv config file to run scripts without full path (e.g. `br` instead of `scripts/br`)

If you want I can pull these out of the pull request :)
