### PR TITLE
draw PDF/SVG over a white background

### DIFF
--- a/DYImageView.h
+++ b/DYImageView.h
@@ -40,6 +40,7 @@
 @property (nonatomic) BOOL scalesUp;
 @property (nonatomic) BOOL showActualSize;
 @property (nonatomic) NSColor *imageBackgroundColor;
+@property (nonatomic) BOOL preferWhiteBackground; // for PDF/SVG, which usually assume a white page behind their transparency
 @property (nonatomic, weak) id<DYImageViewDelegate> delegate;
 
 - (void)setCursor;

--- a/DYImageView.m
+++ b/DYImageView.m
@@ -166,7 +166,9 @@ static NSRect ZoomAlignedRect(NSRect r, float zoom, CGFloat backingScaleFactor) 
 	NSAffineTransform *transform = [self drawingTransform];
 	[transform concat];
 	
-	[_imageBackgroundColor set]; // background for transparent gifs
+	// PDFs and SVGs are usually dark text/art on a transparent page, so always back them
+	// with white rather than the user-chosen transparent-image background color
+	[(_preferWhiteBackground ? NSColor.whiteColor : _imageBackgroundColor) set];
 	[NSBezierPath fillRect:destRect];
 
 	NSGraphicsContext *cg = NSGraphicsContext.currentContext;

--- a/DYWrappingMatrix.m
+++ b/DYWrappingMatrix.m
@@ -621,7 +621,9 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 			//NSLog(@"skipped cell %i", i);
 			continue;
 		}
-		[_imageBackgroundColor set]; // for transparent images
+		// PDFs and SVGs assume a white page behind their transparency, so always back them
+		// with white rather than the user-chosen transparent-image background color
+		[(IsNotCGImage(filename.pathExtension.lowercaseString) ? NSColor.whiteColor : _imageBackgroundColor) set];
 		[NSBezierPath fillRect:[self backingAlignedRect:cellRect options:NSAlignAllEdgesInward]];
 		if (autoRotate) {
 			unsigned short orientation = [self exifOrientationForIndex:i];

--- a/SlideshowWindow.m
+++ b/SlideshowWindow.m
@@ -694,6 +694,7 @@ scheduledTimerWithTimeInterval:timerIntvl
 		BOOL imgFlipped = [flips[theFile] boolValue];
 		
 		if (hideInfoFld) infoFld.hidden = YES; // this must happen before setImage, for redraw purposes
+		imgView.preferWhiteBackground = IsNotCGImage(resolvedPath.pathExtension.lowercaseString);
 		DYImageInfo *info = [imgCache infoForKey:resolvedPath];
 		if (autoRotate && !rot && !imgFlipped && info->exifOrientation > 1) {
 			// auto-rotate by exif orientation


### PR DESCRIPTION
These formats usually assume a white page behind their transparency, so back them with white in both the slideshow image view and the thumbnail