### PR TITLE
Configurable shortcuts, Finder-style browsing, rename/delete and other quality-of-life improvements

### DIFF
--- a/Base.lproj/CreeveyWindow.xib
+++ b/Base.lproj/CreeveyWindow.xib
@@ -70,11 +70,9 @@ DQ
                                     </customView>
                                     <button toolTip="Search all subfolders for images (slower)." horizontalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="370">
                                         <rect key="frame" x="272" y="7" width="98" height="16"/>
-                                        <buttonCell key="cell" type="check" title="Subfolders ⌘F" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="517">
+                                        <buttonCell key="cell" type="check" title="Subfolders ⌘⇧F" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="517">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
-                                            <string key="keyEquivalent">f</string>
-                                            <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                                         </buttonCell>
                                         <connections>
                                             <action selector="setRecurseSubfolders:" target="-2" id="505"/>

--- a/Base.lproj/CreeveyWindow.xib
+++ b/Base.lproj/CreeveyWindow.xib
@@ -14,6 +14,7 @@
                 <outlet property="slidesBtn" destination="368" id="497"/>
                 <outlet property="statusFld" destination="367" id="511"/>
                 <outlet property="subfoldersButton" destination="370" id="eiX-vT-wMP"/>
+                <outlet property="unsupportedButton" destination="Uns-btn-901" id="Uns-out-902"/>
                 <outlet property="window" destination="21" id="501"/>
             </connections>
         </customObject>
@@ -79,15 +80,27 @@ DQ
                                             <action selector="setRecurseSubfolders:" target="-2" id="505"/>
                                         </connections>
                                     </button>
+                                    <button toolTip="Show files the app can't display; preview them with Quick Look." horizontalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Uns-btn-901">
+                                        <rect key="frame" x="378" y="7" width="104" height="16"/>
+                                        <buttonCell key="cell" type="check" title="Unsupported ⌥⌘U" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="Uns-cel-902">
+                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                            <font key="font" metaFont="smallSystem"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="toggleUnsupportedFilesButton:" target="-2" id="Uns-act-903"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="369" firstAttribute="leading" secondItem="361" secondAttribute="leading" id="0Gt-bq-klX"/>
-                                    <constraint firstItem="370" firstAttribute="leading" secondItem="367" secondAttribute="trailing" constant="7" id="EpI-9y-Bxb"/>
+                                    <constraint firstItem="Uns-btn-901" firstAttribute="leading" secondItem="367" secondAttribute="trailing" constant="7" id="EpI-9y-Bxb"/>
                                     <constraint firstItem="368" firstAttribute="centerY" secondItem="367" secondAttribute="centerY" id="OXe-9M-d3l"/>
                                     <constraint firstItem="368" firstAttribute="centerY" secondItem="370" secondAttribute="centerY" id="PUe-ei-kG0"/>
                                     <constraint firstAttribute="bottom" secondItem="368" secondAttribute="bottom" constant="5" id="SQc-ZC-bql"/>
                                     <constraint firstItem="369" firstAttribute="top" secondItem="361" secondAttribute="top" id="UOj-BD-ab1"/>
                                     <constraint firstItem="368" firstAttribute="leading" secondItem="370" secondAttribute="trailing" constant="8" id="atT-f2-wya"/>
+                                    <constraint firstItem="370" firstAttribute="leading" secondItem="Uns-btn-901" secondAttribute="trailing" constant="8" id="Uns-con-904"/>
+                                    <constraint firstItem="Uns-btn-901" firstAttribute="centerY" secondItem="370" secondAttribute="centerY" id="Uns-con-905"/>
                                     <constraint firstAttribute="trailing" secondItem="368" secondAttribute="trailing" constant="20" id="fsf-er-yas"/>
                                     <constraint firstAttribute="trailing" secondItem="369" secondAttribute="trailing" id="l8K-Im-mmu"/>
                                     <constraint firstItem="368" firstAttribute="top" secondItem="369" secondAttribute="bottom" constant="11" id="nbD-kk-nKC"/>

--- a/Base.lproj/CreeveyWindow.xib
+++ b/Base.lproj/CreeveyWindow.xib
@@ -70,9 +70,9 @@ DQ
                                     </customView>
                                     <button toolTip="Search all subfolders for images (slower)." horizontalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="370">
                                         <rect key="frame" x="272" y="7" width="98" height="16"/>
-                                        <buttonCell key="cell" type="check" title="Subfolders ⌘⇧F" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="517">
+                                        <buttonCell key="cell" type="check" title="Subfolders ⌘⇧F" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="517">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                            <font key="font" metaFont="smallSystem"/>
+                                            <font key="font" metaFont="system"/>
                                         </buttonCell>
                                         <connections>
                                             <action selector="setRecurseSubfolders:" target="-2" id="505"/>
@@ -80,9 +80,9 @@ DQ
                                     </button>
                                     <button toolTip="Show files the app can't display; preview them with Quick Look." horizontalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Uns-btn-901">
                                         <rect key="frame" x="378" y="7" width="104" height="16"/>
-                                        <buttonCell key="cell" type="check" title="Unsupported ⌥⌘U" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="Uns-cel-902">
+                                        <buttonCell key="cell" type="check" title="Unsupported ⌥⌘U" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="Uns-cel-902">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                            <font key="font" metaFont="smallSystem"/>
+                                            <font key="font" metaFont="system"/>
                                         </buttonCell>
                                         <connections>
                                             <action selector="toggleUnsupportedFilesButton:" target="-2" id="Uns-act-903"/>

--- a/Base.lproj/MainMenu.xib
+++ b/Base.lproj/MainMenu.xib
@@ -102,6 +102,12 @@
                                     <action selector="newTab:" target="207" id="dzm-5C-yPs"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Go to Folder…" tag="24" keyEquivalent="g" id="GtF-mi-001">
+                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                <connections>
+                                    <action selector="goToFolder:" target="207" id="GtF-ac-002"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Close Window" keyEquivalent="w" id="499">
                                 <connections>
                                     <action selector="performClose:" target="-1" id="500"/>

--- a/Base.lproj/MainMenu.xib
+++ b/Base.lproj/MainMenu.xib
@@ -121,6 +121,12 @@
                                     </connections>
                                 </menu>
                             </menuItem>
+                            <menuItem title="Search" tag="29" keyEquivalent="f" id="Sch-mi-001">
+                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                                <connections>
+                                    <action selector="searchImages:" target="207" id="Sch-ac-002"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Close Window" keyEquivalent="w" id="499">
                                 <connections>
                                     <action selector="performClose:" target="-1" id="500"/>
@@ -146,14 +152,6 @@ IA
                             <menuItem isSeparatorItem="YES" id="485">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
-                            <menuItem title="Set As Desktop Picture" tag="5" keyEquivalent="d" id="391">
-                                <connections>
-                                    <action selector="setDesktopPicture:" target="207" id="414"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem isSeparatorItem="YES" id="79">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
                             <menuItem title="Reveal In Finder" tag="1" keyEquivalent="r" id="341">
                                 <connections>
                                     <action selector="revealSelectedFilesInFinder:" target="207" id="344"/>
@@ -165,6 +163,7 @@ IA
                                     <action selector="copySelectedFilePaths:" target="207" id="Cpn-me-201"/>
                                 </connections>
                             </menuItem>
+                            <menuItem isSeparatorItem="YES" id="Fsp-a1-001"/>
                             <menuItem title="Rename…" tag="16" id="Rn1-me-100">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
@@ -195,6 +194,7 @@ IA
                                     <action selector="copySelectedFilesAgain:" target="207" id="e5p-33-1uv"/>
                                 </connections>
                             </menuItem>
+                            <menuItem isSeparatorItem="YES" id="Fsp-a2-001"/>
                             <menuItem title="Move To Trash" tag="2" id="343">
                                 <string key="keyEquivalent" base64-UTF8="YES">
 CA
@@ -210,6 +210,12 @@ CA
                                 <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                 <connections>
                                     <action selector="deleteSelectedFilesPermanently:" target="207" id="Dl2-me-103"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="Fsp-a3-001"/>
+                            <menuItem title="Set As Desktop Picture" tag="5" keyEquivalent="d" id="391">
+                                <connections>
+                                    <action selector="setDesktopPicture:" target="207" id="414"/>
                                 </connections>
                             </menuItem>
                         </items>
@@ -330,6 +336,12 @@ CA
                                 <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                 <connections>
                                     <action selector="togglePathBar:" target="207" id="PBr-ac-002"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Search Subfolders" tag="30" keyEquivalent="f" id="Sbf-mi-001">
+                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                <connections>
+                                    <action selector="toggleSubfolders:" target="207" id="Sbf-ac-002"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Show Unsupported Files" tag="27" keyEquivalent="u" id="Uns-mi-001">

--- a/Base.lproj/MainMenu.xib
+++ b/Base.lproj/MainMenu.xib
@@ -357,6 +357,37 @@ CA
                                     <action selector="doAutoRotateDisplayedImage:" target="207" id="861"/>
                                 </connections>
                             </menuItem>
+                            <menuItem isSeparatorItem="YES" id="Zm0-sep-000"/>
+                            <menuItem title="Zoom" id="Zmn-par-001">
+                                <menu key="submenu" title="Zoom" id="Zmn-sub-001">
+                                    <items>
+                                        <menuItem title="Zoom In" tag="31" keyEquivalent="+" id="Zm1-in-0001">
+                                            <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                                            <connections>
+                                                <action selector="zoomIn:" target="-1" id="Zm1-in-a001"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Zoom Out" tag="32" keyEquivalent="-" id="Zm2-ot-0001">
+                                            <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                                            <connections>
+                                                <action selector="zoomOut:" target="-1" id="Zm2-ot-a001"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Actual Size" tag="33" keyEquivalent="0" id="Zm3-ac-0001">
+                                            <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                                            <connections>
+                                                <action selector="zoomActualSize:" target="-1" id="Zm3-ac-a001"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Fit to Window" tag="34" keyEquivalent="9" id="Zm4-ft-0001">
+                                            <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                                            <connections>
+                                                <action selector="zoomFitToWindow:" target="-1" id="Zm4-ft-a001"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
                         </items>
                     </menu>
                 </menuItem>

--- a/Base.lproj/MainMenu.xib
+++ b/Base.lproj/MainMenu.xib
@@ -301,6 +301,18 @@ CA
                                     <action selector="doShowFilenames:" target="207" id="856"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Show Directory Browser" tag="25" keyEquivalent="b" id="FBr-mi-001">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="toggleDirectoryBrowser:" target="207" id="FBr-ac-002"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Show Path Bar" tag="26" keyEquivalent="p" id="PBr-mi-001">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="togglePathBar:" target="207" id="PBr-ac-002"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="859"/>
                             <menuItem title="Auto-Rotate by Orientation Tag" tag="261" id="860">
                                 <modifierMask key="keyEquivalentModifierMask"/>

--- a/Base.lproj/MainMenu.xib
+++ b/Base.lproj/MainMenu.xib
@@ -32,6 +32,27 @@
                                     <action selector="openPrefWin:" target="207" id="411"/>
                                 </connections>
                             </menuItem>
+                            <menuItem isSeparatorItem="YES" id="cfg-sep-00">
+                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                            </menuItem>
+                            <menuItem title="Edit Configuration" id="cfg-ed-i00">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="editConfiguration:" target="207" id="cfg-ed-i01"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Reload Configuration" id="cfg-rl-d00">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="reloadConfiguration:" target="207" id="cfg-rl-d01"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Reveal Configuration in Finder" id="cfg-rv-l00">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="revealConfiguration:" target="207" id="cfg-rv-l01"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="143">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
@@ -71,7 +92,7 @@
                 <menuItem title="File" tag="300" id="83">
                     <menu key="submenu" title="File" id="81">
                         <items>
-                            <menuItem title="New Window" keyEquivalent="n" id="494">
+                            <menuItem title="New Window" tag="18" keyEquivalent="n" id="494">
                                 <connections>
                                     <action selector="newWindow:" target="207" id="496"/>
                                 </connections>
@@ -204,7 +225,7 @@ CA
                                     <action selector="selectAll:" target="-1" id="351"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Select None" keyEquivalent="A" id="334">
+                            <menuItem title="Select None" tag="19" keyEquivalent="A" id="334">
                                 <connections>
                                     <action selector="selectNone:" target="-1" id="388"/>
                                 </connections>

--- a/Base.lproj/MainMenu.xib
+++ b/Base.lproj/MainMenu.xib
@@ -110,6 +110,12 @@
                                     <action selector="revealSelectedFilesInFinder:" target="207" id="344"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Rename…" tag="16" id="Rn1-me-100">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="renameSelectedFile:" target="207" id="Rn2-me-102"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Move To..." tag="12" id="SpE-qb-DUd">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
@@ -140,6 +146,15 @@ CA
 </string>
                                 <connections>
                                     <action selector="moveToTrash:" target="207" id="501"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Delete Immediately" tag="17" id="Dl1-me-101">
+                                <string key="keyEquivalent" base64-UTF8="YES">
+CA
+</string>
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="deleteSelectedFilesPermanently:" target="207" id="Dl2-me-103"/>
                                 </connections>
                             </menuItem>
                         </items>

--- a/Base.lproj/MainMenu.xib
+++ b/Base.lproj/MainMenu.xib
@@ -146,6 +146,12 @@ IA
                                     <action selector="revealSelectedFilesInFinder:" target="207" id="344"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Copy as Pathname" tag="28" keyEquivalent="c" id="Cpn-me-200">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="copySelectedFilePaths:" target="207" id="Cpn-me-201"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Rename…" tag="16" id="Rn1-me-100">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>

--- a/Base.lproj/MainMenu.xib
+++ b/Base.lproj/MainMenu.xib
@@ -313,6 +313,12 @@ CA
                                     <action selector="togglePathBar:" target="207" id="PBr-ac-002"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Show Unsupported Files" tag="27" keyEquivalent="u" id="Uns-mi-001">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="toggleUnsupportedFiles:" target="207" id="Uns-ac-002"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="859"/>
                             <menuItem title="Auto-Rotate by Orientation Tag" tag="261" id="860">
                                 <modifierMask key="keyEquivalentModifierMask"/>

--- a/Base.lproj/MainMenu.xib
+++ b/Base.lproj/MainMenu.xib
@@ -27,7 +27,7 @@
                             <menuItem isSeparatorItem="YES" id="196">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
-                            <menuItem title="Preferences…" keyEquivalent="," id="129">
+                            <menuItem title="Preferences…" tag="21" keyEquivalent="," id="129">
                                 <connections>
                                     <action selector="openPrefWin:" target="207" id="411"/>
                                 </connections>
@@ -415,7 +415,7 @@ DQ
                                     <action selector="slideshowAlternateMode:" target="207" id="pLp-k2-hup"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="End Slideshow" id="329">
+                            <menuItem title="End Slideshow" tag="22" id="329">
                                 <string key="keyEquivalent" base64-UTF8="YES">
 Gw
 </string>
@@ -454,7 +454,7 @@ Gw
                             <menuItem isSeparatorItem="YES" id="417">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
-                            <menuItem title="Show Cheat Sheet" keyEquivalent="?" id="418">
+                            <menuItem title="Show Cheat Sheet" tag="23" keyEquivalent="?" id="418">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="toggleCheatSheet:" target="210" id="419"/>

--- a/Base.lproj/MainMenu.xib
+++ b/Base.lproj/MainMenu.xib
@@ -108,6 +108,19 @@
                                     <action selector="goToFolder:" target="207" id="GtF-ac-002"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Open Recent" id="ORc-mi-001">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Open Recent" autoenablesItems="NO" id="ORc-menu-001">
+                                    <items>
+                                        <menuItem title="No Recent Folders" enabled="NO" id="ORc-ph-001">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                        </menuItem>
+                                    </items>
+                                    <connections>
+                                        <outlet property="delegate" destination="207" id="ORc-del-001"/>
+                                    </connections>
+                                </menu>
+                            </menuItem>
                             <menuItem title="Close Window" keyEquivalent="w" id="499">
                                 <connections>
                                     <action selector="performClose:" target="-1" id="500"/>

--- a/Base.lproj/MainMenu.xib
+++ b/Base.lproj/MainMenu.xib
@@ -115,6 +115,15 @@
                                     <action selector="openGetInfoPanel:" target="207" id="489"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Quick Look" tag="20" id="QLk-mi-001">
+                                <string key="keyEquivalent" base64-UTF8="YES">
+IA
+</string>
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="quickLook:" target="207" id="QLk-ac-002"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="485">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>

--- a/Base.lproj/MainMenu.xib
+++ b/Base.lproj/MainMenu.xib
@@ -631,9 +631,9 @@ Gw
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="194" id="Iag-qm-od0"/>
                         </constraints>
                     </progressIndicator>
-                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="458">
+                    <textField tag="2" focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="458">
                         <rect key="frame" x="18" y="59" width="198" height="16"/>
-                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Processing files..." id="835">
+                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" lineBreakMode="truncatingMiddle" title="Processing files..." id="835">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>

--- a/Base.lproj/MainMenu.xib
+++ b/Base.lproj/MainMenu.xib
@@ -176,24 +176,14 @@ IA
                                     <action selector="moveSelectedFiles:" target="207" id="1cb-Eq-3Ik"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Move To Folder Again" tag="13" keyEquivalent="m" id="c0g-qO-OVm">
-                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
-                                <connections>
-                                    <action selector="moveSelectedFilesAgain:" target="207" id="cVY-9b-EDj"/>
-                                </connections>
-                            </menuItem>
+                            <menuItem title="Move To Recent" tag="13" id="c0g-qO-OVm"/>
                             <menuItem title="Copy To..." tag="14" id="e4f-92-7kq">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="copySelectedFiles:" target="207" id="a1b-45-7c2"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Copy To Folder Again" tag="15" keyEquivalent="c" id="b2k-58-4mj">
-                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
-                                <connections>
-                                    <action selector="copySelectedFilesAgain:" target="207" id="e5p-33-1uv"/>
-                                </connections>
-                            </menuItem>
+                            <menuItem title="Copy To Recent" tag="15" id="b2k-58-4mj"/>
                             <menuItem isSeparatorItem="YES" id="Fsp-a2-001"/>
                             <menuItem title="Move To Trash" tag="2" id="343">
                                 <string key="keyEquivalent" base64-UTF8="YES">

--- a/Base.lproj/PrefsWin.xib
+++ b/Base.lproj/PrefsWin.xib
@@ -354,7 +354,7 @@
                                             </connections>
                                         </button>
                                         <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ORp-lbl-001">
-                                            <rect key="frame" x="20" y="70" width="120" height="16"/>
+                                            <rect key="frame" x="248" y="111" width="122" height="16"/>
                                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Open Recent count:" id="ORp-lbc-001">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -362,7 +362,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ORp-fld-001">
-                                            <rect key="frame" x="148" y="67" width="46" height="22"/>
+                                            <rect key="frame" x="376" y="108" width="46" height="22"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="right" borderStyle="bezel" drawsBackground="YES" id="ORp-fcl-001">
                                                 <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" maximumFractionDigits="0" id="ORp-fmt-001">
                                                     <real key="minimum" value="1"/>
@@ -377,7 +377,7 @@
                                             </connections>
                                         </textField>
                                         <stepper verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ORp-stp-001">
-                                            <rect key="frame" x="197" y="64" width="19" height="27"/>
+                                            <rect key="frame" x="428" y="106" width="19" height="27"/>
                                             <stepperCell key="cell" continuous="YES" alignment="left" increment="1" minValue="1" maxValue="50" doubleValue="10" id="ORp-scl-001"/>
                                             <connections>
                                                 <binding destination="551" name="value" keyPath="values.recentFoldersMax" id="ORp-svb-001"/>
@@ -459,7 +459,7 @@
                                         <constraint firstItem="JE2-gK-vCp" firstAttribute="leading" secondItem="vJq-9X-o03" secondAttribute="leading" id="NCw-JO-QGE"/>
                                         <constraint firstItem="xKo-Ye-awl" firstAttribute="leading" secondItem="590" secondAttribute="leading" constant="20" symbolic="YES" id="Ni5-rS-kEt"/>
                                         <constraint firstItem="574" firstAttribute="top" secondItem="Cpq-btn-001" secondAttribute="bottom" constant="6" symbolic="YES" id="Pfk-4i-1Dn"/>
-                                        <constraint firstItem="Cpq-btn-001" firstAttribute="top" secondItem="689" secondAttribute="bottom" constant="6" symbolic="YES" id="Cpq-con-101"/>
+                                        <constraint firstItem="Cpq-btn-001" firstAttribute="top" secondItem="689" secondAttribute="bottom" constant="10" symbolic="YES" id="Cpq-con-101"/>
                                         <constraint firstItem="Cpq-btn-001" firstAttribute="leading" secondItem="590" secondAttribute="leading" constant="20" symbolic="YES" id="Cpq-con-102"/>
                                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Cpq-btn-001" secondAttribute="trailing" priority="250" constant="20" symbolic="YES" id="Cpq-con-103"/>
                                         <constraint firstItem="398" firstAttribute="leading" secondItem="689" secondAttribute="leading" priority="750" id="Pw3-fA-eke"/>
@@ -506,6 +506,14 @@
                                         <constraint firstAttribute="trailing" secondItem="403" secondAttribute="trailing" constant="20" symbolic="YES" id="xSl-3k-enI"/>
                                         <constraint firstItem="JE2-gK-vCp" firstAttribute="top" secondItem="vJq-9X-o03" secondAttribute="bottom" constant="6" symbolic="YES" id="xfG-2R-8hS"/>
                                         <constraint firstItem="xMi-Ox-Qfm" firstAttribute="leading" secondItem="xKo-Ye-awl" secondAttribute="trailing" constant="8" symbolic="YES" id="yde-Kk-wOv"/>
+                                        <constraint firstItem="ORp-lbl-001" firstAttribute="centerY" secondItem="689" secondAttribute="centerY" id="ORp-con-201"/>
+                                        <constraint firstItem="ORp-fld-001" firstAttribute="centerY" secondItem="689" secondAttribute="centerY" id="ORp-con-202"/>
+                                        <constraint firstItem="ORp-stp-001" firstAttribute="centerY" secondItem="689" secondAttribute="centerY" id="ORp-con-203"/>
+                                        <constraint firstItem="ORp-fld-001" firstAttribute="leading" secondItem="ORp-lbl-001" secondAttribute="trailing" constant="6" symbolic="YES" id="ORp-con-204"/>
+                                        <constraint firstItem="ORp-stp-001" firstAttribute="leading" secondItem="ORp-fld-001" secondAttribute="trailing" constant="6" symbolic="YES" id="ORp-con-205"/>
+                                        <constraint firstAttribute="trailing" secondItem="ORp-stp-001" secondAttribute="trailing" constant="20" symbolic="YES" id="ORp-con-206"/>
+                                        <constraint firstItem="ORp-fld-001" firstAttribute="width" constant="46" id="ORp-con-207"/>
+                                        <constraint firstItem="ORp-lbl-001" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="689" secondAttribute="trailing" constant="12" id="ORp-con-208"/>
                                     </constraints>
                                 </view>
                             </tabViewItem>

--- a/Base.lproj/PrefsWin.xib
+++ b/Base.lproj/PrefsWin.xib
@@ -354,8 +354,8 @@
                                             </connections>
                                         </button>
                                         <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ORp-lbl-001">
-                                            <rect key="frame" x="248" y="111" width="122" height="16"/>
-                                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Open Recent count:" id="ORp-lbc-001">
+                                            <rect key="frame" x="210" y="111" width="160" height="16"/>
+                                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Recent paths to keep:" id="ORp-lbc-001">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>

--- a/Base.lproj/PrefsWin.xib
+++ b/Base.lproj/PrefsWin.xib
@@ -343,6 +343,16 @@
                                                 <binding destination="551" name="value" keyPath="values.DYWrappingMatrixAllowMove" id="694"/>
                                             </connections>
                                         </button>
+                                        <button toolTip="When on, Copy as Pathname produces shell-quoted paths (safe for spaces and special characters); when off, raw Finder-style paths." translatesAutoresizingMaskIntoConstraints="NO" id="Cpq-btn-001">
+                                            <rect key="frame" x="20" y="95" width="240" height="16"/>
+                                            <buttonCell key="cell" type="check" title="Shell-quote copied pathnames" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="Cpq-cel-002">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <binding destination="551" name="value" keyPath="values.copyPathnameShellQuoted" id="Cpq-bnd-003"/>
+                                            </connections>
+                                        </button>
                                         <button translatesAutoresizingMaskIntoConstraints="NO" id="548">
                                             <rect key="frame" x="20" y="67" width="217" height="16"/>
                                             <buttonCell key="cell" type="check" title="Automatically check for updates" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="818">
@@ -418,7 +428,10 @@
                                         <constraint firstItem="2rn-Xo-dYj" firstAttribute="top" secondItem="4Bj-yv-gIT" secondAttribute="bottom" constant="8" symbolic="YES" id="LgP-Ej-MYf"/>
                                         <constraint firstItem="JE2-gK-vCp" firstAttribute="leading" secondItem="vJq-9X-o03" secondAttribute="leading" id="NCw-JO-QGE"/>
                                         <constraint firstItem="xKo-Ye-awl" firstAttribute="leading" secondItem="590" secondAttribute="leading" constant="20" symbolic="YES" id="Ni5-rS-kEt"/>
-                                        <constraint firstItem="574" firstAttribute="top" secondItem="689" secondAttribute="bottom" constant="6" symbolic="YES" id="Pfk-4i-1Dn"/>
+                                        <constraint firstItem="574" firstAttribute="top" secondItem="Cpq-btn-001" secondAttribute="bottom" constant="6" symbolic="YES" id="Pfk-4i-1Dn"/>
+                                        <constraint firstItem="Cpq-btn-001" firstAttribute="top" secondItem="689" secondAttribute="bottom" constant="6" symbolic="YES" id="Cpq-con-101"/>
+                                        <constraint firstItem="Cpq-btn-001" firstAttribute="leading" secondItem="590" secondAttribute="leading" constant="20" symbolic="YES" id="Cpq-con-102"/>
+                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Cpq-btn-001" secondAttribute="trailing" priority="250" constant="20" symbolic="YES" id="Cpq-con-103"/>
                                         <constraint firstItem="398" firstAttribute="leading" secondItem="689" secondAttribute="leading" priority="750" id="Pw3-fA-eke"/>
                                         <constraint firstAttribute="trailing" secondItem="575" secondAttribute="trailing" constant="20" symbolic="YES" id="Qed-5b-Wm2"/>
                                         <constraint firstItem="398" firstAttribute="leading" secondItem="697" secondAttribute="leading" id="Qhd-zx-ehV"/>

--- a/Base.lproj/PrefsWin.xib
+++ b/Base.lproj/PrefsWin.xib
@@ -196,6 +196,7 @@
                                                         <menuItem title="Small" state="on" id="Txt-s0-sm"/>
                                                         <menuItem title="Medium" id="Txt-s0-md"/>
                                                         <menuItem title="Large" id="Txt-s0-lg"/>
+                                                        <menuItem title="Custom" id="Txt-s0-cst"/>
                                                     </items>
                                                 </menu>
                                             </popUpButtonCell>
@@ -203,6 +204,46 @@
                                                 <binding destination="551" name="selectedIndex" keyPath="values.interfaceTextSize" id="Txt-s0-bnd"/>
                                             </connections>
                                         </popUpButton>
+                                        <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Txt-s0-fld">
+                                            <rect key="frame" x="393" y="281" width="42" height="22"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="right" borderStyle="bezel" drawsBackground="YES" id="Txt-s0-fcl">
+                                                <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" maximumFractionDigits="0" id="Txt-s0-fmt">
+                                                    <real key="minimum" value="10"/>
+                                                    <real key="maximum" value="25"/>
+                                                </numberFormatter>
+                                                <font key="font" metaFont="message"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                            <connections>
+                                                <binding destination="551" name="value" keyPath="values.interfaceTextCustomSize" id="Txt-s0-fvb"/>
+                                                <binding destination="551" name="enabled" keyPath="values.interfaceTextSize" id="Txt-s0-feb">
+                                                    <dictionary key="options">
+                                                        <string key="NSValueTransformerName">DYTextSizeIsCustomTransformer</string>
+                                                    </dictionary>
+                                                </binding>
+                                            </connections>
+                                        </textField>
+                                        <stepper verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Txt-s0-stp">
+                                            <rect key="frame" x="438" y="278" width="19" height="27"/>
+                                            <stepperCell key="cell" continuous="YES" alignment="left" increment="1" minValue="10" maxValue="25" doubleValue="13" id="Txt-s0-scl"/>
+                                            <connections>
+                                                <binding destination="551" name="value" keyPath="values.interfaceTextCustomSize" id="Txt-s0-svb"/>
+                                                <binding destination="551" name="enabled" keyPath="values.interfaceTextSize" id="Txt-s0-seb">
+                                                    <dictionary key="options">
+                                                        <string key="NSValueTransformerName">DYTextSizeIsCustomTransformer</string>
+                                                    </dictionary>
+                                                </binding>
+                                            </connections>
+                                        </stepper>
+                                        <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Txt-s0-ptl">
+                                            <rect key="frame" x="460" y="284" width="18" height="16"/>
+                                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="pt" id="Txt-s0-pc2">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
                                         <colorWell translatesAutoresizingMaskIntoConstraints="NO" id="697">
                                             <rect key="frame" x="20" y="246" width="42" height="29"/>
                                             <constraints>

--- a/Base.lproj/PrefsWin.xib
+++ b/Base.lproj/PrefsWin.xib
@@ -178,6 +178,31 @@
                                                 <binding destination="551" name="selectedIndex" keyPath="values.appearance" id="vht-td-m0h"/>
                                             </connections>
                                         </popUpButton>
+                                        <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Txt-s0-lbl">
+                                            <rect key="frame" x="214" y="284" width="66" height="16"/>
+                                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Text size:" id="Txt-s0-cel">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Txt-s0-pop">
+                                            <rect key="frame" x="282" y="280" width="105" height="24"/>
+                                            <popUpButtonCell key="cell" type="push" title="Small" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="Txt-s0-sm" id="Txt-s0-pcl">
+                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="message"/>
+                                                <menu key="menu" id="Txt-s0-mnu">
+                                                    <items>
+                                                        <menuItem title="Small" state="on" id="Txt-s0-sm"/>
+                                                        <menuItem title="Medium" id="Txt-s0-md"/>
+                                                        <menuItem title="Large" id="Txt-s0-lg"/>
+                                                    </items>
+                                                </menu>
+                                            </popUpButtonCell>
+                                            <connections>
+                                                <binding destination="551" name="selectedIndex" keyPath="values.interfaceTextSize" id="Txt-s0-bnd"/>
+                                            </connections>
+                                        </popUpButton>
                                         <colorWell translatesAutoresizingMaskIntoConstraints="NO" id="697">
                                             <rect key="frame" x="20" y="246" width="42" height="29"/>
                                             <constraints>

--- a/Base.lproj/PrefsWin.xib
+++ b/Base.lproj/PrefsWin.xib
@@ -353,6 +353,36 @@
                                                 <binding destination="551" name="value" keyPath="values.copyPathnameShellQuoted" id="Cpq-bnd-003"/>
                                             </connections>
                                         </button>
+                                        <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ORp-lbl-001">
+                                            <rect key="frame" x="20" y="70" width="120" height="16"/>
+                                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Open Recent count:" id="ORp-lbc-001">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ORp-fld-001">
+                                            <rect key="frame" x="148" y="67" width="46" height="22"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="right" borderStyle="bezel" drawsBackground="YES" id="ORp-fcl-001">
+                                                <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" maximumFractionDigits="0" id="ORp-fmt-001">
+                                                    <real key="minimum" value="1"/>
+                                                    <real key="maximum" value="50"/>
+                                                </numberFormatter>
+                                                <font key="font" metaFont="message"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                            <connections>
+                                                <binding destination="551" name="value" keyPath="values.recentFoldersMax" id="ORp-fvb-001"/>
+                                            </connections>
+                                        </textField>
+                                        <stepper verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ORp-stp-001">
+                                            <rect key="frame" x="197" y="64" width="19" height="27"/>
+                                            <stepperCell key="cell" continuous="YES" alignment="left" increment="1" minValue="1" maxValue="50" doubleValue="10" id="ORp-scl-001"/>
+                                            <connections>
+                                                <binding destination="551" name="value" keyPath="values.recentFoldersMax" id="ORp-svb-001"/>
+                                            </connections>
+                                        </stepper>
                                         <button translatesAutoresizingMaskIntoConstraints="NO" id="548">
                                             <rect key="frame" x="20" y="67" width="217" height="16"/>
                                             <buttonCell key="cell" type="check" title="Automatically check for updates" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="818">

--- a/Base.lproj/ThumbnailContextMenu.xib
+++ b/Base.lproj/ThumbnailContextMenu.xib
@@ -22,6 +22,12 @@
                         <action selector="revealSelectedFilesInFinder:" target="-2" id="PjH-Hp-X5V"/>
                     </connections>
                 </menuItem>
+                <menuItem title="Copy as Pathname" keyEquivalent="c" id="Cpn-mi-001">
+                    <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                    <connections>
+                        <action selector="copySelectedFilePaths:" target="-2" id="Cpn-ac-002"/>
+                    </connections>
+                </menuItem>
                 <menuItem isSeparatorItem="YES" id="1zy-oe-nmR"/>
             </items>
             <point key="canvasLocation" x="611" y="532.5"/>

--- a/Credits.html
+++ b/Credits.html
@@ -3,6 +3,12 @@
 <head>
 	<meta charset="utf-8">
 	<title>Phoenix Slides Credits</title>
+	<style>
+		body { font-family: -apple-system, "Helvetica Neue", Helvetica, Arial, sans-serif; font-size: 11px; color: #1d1d1f; margin: 0; }
+		a { color: #0068da; text-decoration: none; }
+		strong { font-weight: 600; }
+		pre { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 9px; white-space: pre-wrap; }
+	</style>
 </head>
 <body>
 <p align="center">Free.

--- a/CreeveyController.h
+++ b/CreeveyController.h
@@ -44,6 +44,7 @@ NSDirectoryEnumerator *CreeveyEnumerator(NSString *path, BOOL recurseSubfolders)
 - (IBAction)slideshow:(id)sender;
 - (IBAction)slideshowAlternateMode:(id)sender;
 - (IBAction)openSelectedFiles:(id)sender;
+- (IBAction)quickLook:(id)sender;
 - (IBAction)revealSelectedFilesInFinder:(id)sender;
 - (IBAction)setDesktopPicture:(id)sender;
 - (IBAction)moveSelectedFiles:(id)sender;

--- a/CreeveyController.h
+++ b/CreeveyController.h
@@ -51,9 +51,11 @@ NSDirectoryEnumerator *CreeveyEnumerator(NSString *path, BOOL recurseSubfolders)
 - (IBAction)copySelectedFilePaths:(id)sender;
 - (IBAction)setDesktopPicture:(id)sender;
 - (IBAction)moveSelectedFiles:(id)sender;
-- (IBAction)moveSelectedFilesAgain:(id)sender;
 - (IBAction)copySelectedFiles:(id)sender;
-- (IBAction)copySelectedFilesAgain:(id)sender;
+- (IBAction)moveToRecentFolder:(id)sender; // File ▸ Move To Recent ▸ <folder>
+- (IBAction)copyToRecentFolder:(id)sender; // File ▸ Copy To Recent ▸ <folder>
+- (void)recordRecentMoveDestination:(NSString *)path; // push a Move destination onto the recent list
+- (void)recordRecentCopyDestination:(NSString *)path; // push a Copy destination onto the recent list
 - (IBAction)moveToTrash:(id)sender;
 - (IBAction)deleteSelectedFilesPermanently:(id)sender;
 - (IBAction)renameSelectedFile:(id)sender;

--- a/CreeveyController.h
+++ b/CreeveyController.h
@@ -8,7 +8,7 @@
 @import Cocoa;
 #define CREEVEY_DEFAULT_PATH [@"~/Pictures" stringByResolvingSymlinksInPath]
 
-@class DYImageCache, SlideshowWindow, DYJpegtranPanel;
+@class DYImageCache, SlideshowWindow, DYJpegtranPanel, KeyBindings;
 
 NSMutableAttributedString* Fileinfo2EXIFString(NSString *origPath, DYImageCache *cache, BOOL moreExif);
 
@@ -33,6 +33,7 @@ NSMutableAttributedString* Fileinfo2EXIFString(NSString *origPath, DYImageCache 
 @property (nonatomic, readonly) NSMutableSet * __strong *cats;
 - (void)updateCats;
 @property (nonatomic, readonly) DYImageCache *thumbsCache;
+@property (nonatomic, readonly) KeyBindings *keyBindings;
 NSDirectoryEnumerator *CreeveyEnumerator(NSString *path, BOOL recurseSubfolders);
 - (BOOL)handledDirectory:(NSURL *)url subfolders:(BOOL)recurse e:(NSDirectoryEnumerator *)e;
 - (BOOL)shouldShowFile:(NSURL *)path;
@@ -66,6 +67,10 @@ NSDirectoryEnumerator *CreeveyEnumerator(NSString *path, BOOL recurseSubfolders)
 // info window
 - (IBAction)openGetInfoPanel:(id)sender;
 - (IBAction)toggleExifThumbnail:(id)sender;
+
+- (IBAction)reloadConfiguration:(id)sender;
+- (IBAction)editConfiguration:(id)sender;
+- (IBAction)revealConfiguration:(id)sender;
 
 - (IBAction)openAboutPanel:(id)sender;
 - (IBAction)stopModal:(id)sender;

--- a/CreeveyController.h
+++ b/CreeveyController.h
@@ -63,6 +63,7 @@ NSDirectoryEnumerator *CreeveyEnumerator(NSString *path, BOOL recurseSubfolders)
 
 // prefs stuff
 - (IBAction)openPrefWin:(id)sender;
+- (IBAction)goToFolder:(id)sender;
 - (IBAction)chooseStartupDir:(id)sender;
 - (IBAction)applySlideshowPrefs:(id)sender;
 - (IBAction)slideshowDefaultsChanged:(id)sender;

--- a/CreeveyController.h
+++ b/CreeveyController.h
@@ -47,6 +47,7 @@ NSDirectoryEnumerator *CreeveyEnumerator(NSString *path, BOOL recurseSubfolders)
 - (IBAction)openSelectedFiles:(id)sender;
 - (IBAction)quickLook:(id)sender;
 - (IBAction)revealSelectedFilesInFinder:(id)sender;
+- (IBAction)copySelectedFilePaths:(id)sender;
 - (IBAction)setDesktopPicture:(id)sender;
 - (IBAction)moveSelectedFiles:(id)sender;
 - (IBAction)moveSelectedFilesAgain:(id)sender;

--- a/CreeveyController.h
+++ b/CreeveyController.h
@@ -12,6 +12,9 @@
 
 NSMutableAttributedString* Fileinfo2EXIFString(NSString *origPath, DYImageCache *cache, BOOL moreExif);
 
+// Multiplier for interface text (1.0 / 1.25 / 1.5) from the "interfaceTextSize" preference.
+CGFloat DYInterfaceTextScale(void);
+
 #define NUM_FNKEY_CATS 11
 
 @interface CreeveyController : NSObject <NSApplicationDelegate,NSTableViewDataSource,NSWindowRestoration>

--- a/CreeveyController.h
+++ b/CreeveyController.h
@@ -40,6 +40,7 @@ CGFloat DYInterfaceTextScale(void);
 NSDirectoryEnumerator *CreeveyEnumerator(NSString *path, BOOL recurseSubfolders);
 - (BOOL)handledDirectory:(NSURL *)url subfolders:(BOOL)recurse e:(NSDirectoryEnumerator *)e;
 - (BOOL)shouldShowFile:(NSURL *)path;
+- (BOOL)shouldShowFile:(NSURL *)url includingUnsupported:(BOOL)includeUnsupported;
 
 - (IBAction)slideshow:(id)sender;
 - (IBAction)slideshowAlternateMode:(id)sender;
@@ -59,6 +60,7 @@ NSDirectoryEnumerator *CreeveyEnumerator(NSString *path, BOOL recurseSubfolders)
 - (IBAction)doShowFilenames:(id)sender;
 - (IBAction)togglePathBar:(id)sender;
 - (IBAction)toggleDirectoryBrowser:(id)sender;
+- (IBAction)toggleUnsupportedFiles:(id)sender;
 - (IBAction)doAutoRotateDisplayedImage:(id)sender;
 
 - (void)slideshowFromAppOpen:(NSArray *)files;

--- a/CreeveyController.h
+++ b/CreeveyController.h
@@ -12,6 +12,9 @@
 
 NSMutableAttributedString* Fileinfo2EXIFString(NSString *origPath, DYImageCache *cache, BOOL moreExif);
 
+// Compact, scrollable alert listing files a Move/Copy operation couldn't process.
+void DYReportFileErrors(NSString *messageText, NSArray<NSString *> *files);
+
 // Multiplier for interface text (1.0 / 1.25 / 1.5) from the "interfaceTextSize" preference.
 CGFloat DYInterfaceTextScale(void);
 

--- a/CreeveyController.h
+++ b/CreeveyController.h
@@ -47,6 +47,8 @@ NSDirectoryEnumerator *CreeveyEnumerator(NSString *path, BOOL recurseSubfolders)
 - (IBAction)copySelectedFiles:(id)sender;
 - (IBAction)copySelectedFilesAgain:(id)sender;
 - (IBAction)moveToTrash:(id)sender;
+- (IBAction)deleteSelectedFilesPermanently:(id)sender;
+- (IBAction)renameSelectedFile:(id)sender;
 - (IBAction)transformJpeg:(id)sender;
 - (IBAction)sortThumbnails:(id)sender;
 - (IBAction)doShowFilenames:(id)sender;

--- a/CreeveyController.h
+++ b/CreeveyController.h
@@ -57,6 +57,8 @@ NSDirectoryEnumerator *CreeveyEnumerator(NSString *path, BOOL recurseSubfolders)
 - (IBAction)transformJpeg:(id)sender;
 - (IBAction)sortThumbnails:(id)sender;
 - (IBAction)doShowFilenames:(id)sender;
+- (IBAction)togglePathBar:(id)sender;
+- (IBAction)toggleDirectoryBrowser:(id)sender;
 - (IBAction)doAutoRotateDisplayedImage:(id)sender;
 
 - (void)slideshowFromAppOpen:(NSArray *)files;

--- a/CreeveyController.h
+++ b/CreeveyController.h
@@ -70,6 +70,8 @@ NSDirectoryEnumerator *CreeveyEnumerator(NSString *path, BOOL recurseSubfolders)
 // prefs stuff
 - (IBAction)openPrefWin:(id)sender;
 - (IBAction)goToFolder:(id)sender;
+- (IBAction)searchImages:(id)sender;
+- (IBAction)toggleSubfolders:(id)sender;
 - (IBAction)chooseStartupDir:(id)sender;
 - (IBAction)applySlideshowPrefs:(id)sender;
 - (IBAction)slideshowDefaultsChanged:(id)sender;

--- a/CreeveyController.h
+++ b/CreeveyController.h
@@ -8,7 +8,7 @@
 @import Cocoa;
 #define CREEVEY_DEFAULT_PATH [@"~/Pictures" stringByResolvingSymlinksInPath]
 
-@class DYImageCache, SlideshowWindow, DYJpegtranPanel, KeyBindings;
+@class DYImageCache, SlideshowWindow, DYJpegtranPanel, KeyBindings, CreeveyMainWindowController;
 
 NSMutableAttributedString* Fileinfo2EXIFString(NSString *origPath, DYImageCache *cache, BOOL moreExif);
 
@@ -40,6 +40,7 @@ CGFloat DYInterfaceTextScale(void);
 NSDirectoryEnumerator *CreeveyEnumerator(NSString *path, BOOL recurseSubfolders);
 - (BOOL)handledDirectory:(NSURL *)url subfolders:(BOOL)recurse e:(NSDirectoryEnumerator *)e;
 - (BOOL)shouldShowFile:(NSURL *)path;
+- (void)noteRecentFolderForWindow:(CreeveyMainWindowController *)wc; // Open Recent: record the window's current folder+state
 - (BOOL)shouldShowFile:(NSURL *)url includingUnsupported:(BOOL)includeUnsupported;
 
 - (IBAction)slideshow:(id)sender;

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -458,6 +458,28 @@ static NSModalResponse DYRunAlert(NSAlert *alert) {
 @property (nonatomic) BOOL windowsWereRestoredAtLaunch;
 @end
 
+// Report files an operation couldn't process in a compact, scrollable alert. A plain informativeText
+// grows the alert past the screen when many paths fail; this caps the size and scrolls instead.
+void DYReportFileErrors(NSString *messageText, NSArray<NSString *> *files) {
+	if (files.count == 0) return;
+	NSAlert *alert = [[NSAlert alloc] init];
+	alert.messageText = messageText;
+	alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"%lu file(s) could not be processed:", @""), (unsigned long)files.count];
+	NSScrollView *scroll = [[NSScrollView alloc] initWithFrame:NSMakeRect(0, 0, 380, 140)];
+	scroll.hasVerticalScroller = YES;
+	scroll.borderType = NSBezelBorder;
+	NSTextView *tv = [[NSTextView alloc] initWithFrame:NSMakeRect(0, 0, 380, 140)];
+	tv.editable = NO;
+	tv.drawsBackground = NO;
+	tv.string = [files componentsJoinedByString:@"\n"];
+	tv.autoresizingMask = NSViewWidthSizable;
+	tv.textContainerInset = NSMakeSize(4, 4);
+	scroll.documentView = tv;
+	alert.accessoryView = scroll;
+	[alert addButtonWithTitle:NSLocalizedString(@"OK", @"")];
+	[alert runModal];
+}
+
 @implementation CreeveyController
 {
 	NSMutableSet *cats[NUM_FNKEY_CATS];
@@ -1122,6 +1144,39 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 	item.title = [NSUserDefaults.standardUserDefaults integerForKey:@"slideshowDefaultMode"] == 0 ? NSLocalizedString(@"Begin Slideshow In Window", @"Slideshow menu") : NSLocalizedString(@"Begin Slideshow (Full Screen)", @"Slideshow menu");
 }
 
+// Batch file-operation progress, reusing the shared "Progress Panel" (bar + label + Cancel) that
+// JPEG transforms use. Only worth showing for multi-file operations; a single file is instant.
+// Returns a modal session to pump, or NULL when no panel is shown (count <= 1).
+- (NSModalSession)beginFileProgress:(NSUInteger)count title:(NSString *)title {
+	if (count <= 1) return NULL;
+	jpegProgressBar.window.title = title;
+	jpegProgressBar.usesThreadedAnimation = NO; // step immediately per file, not eased/animated (no bounce)
+	jpegProgressBar.indeterminate = NO;
+	jpegProgressBar.minValue = 0;
+	jpegProgressBar.doubleValue = 0;
+	jpegProgressBar.maxValue = count;
+	NSTextField *label = [jpegProgressBar.window.contentView viewWithTag:2];
+	label.stringValue = title;
+	((NSButton *)[jpegProgressBar.window.contentView viewWithTag:1]).enabled = YES; // Cancel
+	NSModalSession s = [NSApp beginModalSessionForWindow:jpegProgressBar.window];
+	[NSApp runModalSession:s];
+	return s;
+}
+// Advance the bar one step and show the current file name; returns NO if the user pressed Cancel.
+- (BOOL)stepFileProgress:(NSModalSession)s name:(NSString *)name {
+	if (!s) return YES;
+	NSTextField *label = [jpegProgressBar.window.contentView viewWithTag:2];
+	label.stringValue = name;
+	[jpegProgressBar incrementBy:1];
+	[jpegProgressBar display]; // redraw the exact proportion now, so the fill steps smoothly L→R
+	return [NSApp runModalSession:s] == NSModalResponseContinue;
+}
+- (void)endFileProgress:(NSModalSession)s {
+	if (!s) return;
+	[NSApp endModalSession:s];
+	[jpegProgressBar.window orderOut:self];
+}
+
 - (void)moveSelectedFilesTo:(NSURL *)dest {
 	NSURL *curr = slidesWindow.isMainWindow ? slidesWindow.baseURL : frontWindow.URL;
 	if ([dest isEqual:curr]) return;
@@ -1131,25 +1186,26 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 	NSMutableArray<NSURL*> *moved = [NSMutableArray arrayWithCapacity:files.count];
 	NSMutableArray<NSString*> *notMoved = [NSMutableArray array];
 
-	NSError * __autoreleasing err;
+	NSFileManager *fm = NSFileManager.defaultManager;
+	NSModalSession prog = [self beginFileProgress:files.count title:NSLocalizedString(@"Moving Files…", @"")];
 	for (NSString *f in files) {
 		NSURL *destUrl = [dest URLByAppendingPathComponent:f.lastPathComponent];
-		if ([NSFileManager.defaultManager moveItemAtPath:f toPath:destUrl.path error:&err]) {
+		// Skip files already at the destination (same folder, or a copy of the same name already
+		// there) — that's not an error, so don't report it.
+		if ([destUrl.path isEqualToString:f] || [fm fileExistsAtPath:destUrl.path]) {
+			if (![self stepFileProgress:prog name:f.lastPathComponent]) break;
+			continue;
+		}
+		if ([fm moveItemAtPath:f toPath:destUrl.path error:NULL]) {
 			[paths addObject:f];
 			[moved addObject:destUrl];
 		} else {
 			[notMoved addObject:f];
 		}
+		if (![self stepFileProgress:prog name:f.lastPathComponent]) break; // Cancel: keep what moved
 	}
-	if (notMoved.count) {
-		NSAlert *alert = [[NSAlert alloc] init];
-		if (notMoved.count == 1) {
-			alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"The file “%@” could not be moved because of an error: %@", @""), notMoved[0].lastPathComponent, err.localizedDescription];
-		} else {
-			alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"%lu files could not be moved because of an error.",@""), notMoved.count];
-		}
-		DYRunAlert(alert);
-	}
+	[self endFileProgress:prog];
+	DYReportFileErrors(NSLocalizedString(@"Some files couldn’t be moved.", @""), notMoved);
 	_originalPaths = [paths copy];
 	_movedUrls = [moved copy];
 	[self removePicsAndTrash:NO];
@@ -1163,20 +1219,22 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 	NSArray *files = slidesWindow.isMainWindow ? @[slidesWindow.currentFile] : frontWindow.currentSelection;
 	NSMutableArray<NSString*> *notCopied = [NSMutableArray array];
 
-	NSError * __autoreleasing err;
+	NSFileManager *fm = NSFileManager.defaultManager;
+	NSModalSession prog = [self beginFileProgress:files.count title:NSLocalizedString(@"Copying Files…", @"")];
 	for (NSString *f in files) {
 		NSURL *destUrl = [dest URLByAppendingPathComponent:f.lastPathComponent];
-		if (![NSFileManager.defaultManager copyItemAtPath:f toPath:destUrl.path error:&err])
+		// Skip files already at the destination (copying a file onto itself, or a same-named file
+		// already there) rather than failing with an "already exists" error.
+		if ([destUrl.path isEqualToString:f] || [fm fileExistsAtPath:destUrl.path]) {
+			if (![self stepFileProgress:prog name:f.lastPathComponent]) break;
+			continue;
+		}
+		if (![fm copyItemAtPath:f toPath:destUrl.path error:NULL])
 			[notCopied addObject:f];
+		if (![self stepFileProgress:prog name:f.lastPathComponent]) break; // Cancel: keep what copied
 	}
-	if (notCopied.count) {
-		NSAlert *alert = [[NSAlert alloc] init];
-		if (notCopied.count == 1)
-			alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"The file “%@” could not be copied because of an error: %@", @""), notCopied[0].lastPathComponent, err.localizedDescription];
-		else
-			alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"%lu files could not be copied because of an error.", @""), notCopied.count];
-		DYRunAlert(alert);
-	}
+	[self endFileProgress:prog];
+	DYReportFileErrors(NSLocalizedString(@"Some files couldn’t be copied.", @""), notCopied);
 }
 
 - (IBAction)moveSelectedFiles:(id)sender {

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -391,6 +391,7 @@ static NSModalResponse DYRunAlert(NSAlert *alert) {
 
 - (IBAction)quickLook:(id)sender {
 	QLPreviewPanel *panel = QLPreviewPanel.sharedPreviewPanel;
+	panel.animationBehavior = NSWindowAnimationBehaviorNone; // open/close instantly, no zoom/fade
 	if (QLPreviewPanel.sharedPreviewPanelExists && panel.isVisible)
 		[panel orderOut:nil];
 	else
@@ -1118,6 +1119,12 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 	[_keyBindings load];
 	[_keyBindings applyToMainMenu];
 	[_keyBindings reportErrorsIfAny];
+
+	// warm up Quick Look after launch so the first Space press doesn't also pay the
+	// QuickLookUI framework load / panel creation cost on top of rendering
+	dispatch_async(dispatch_get_main_queue(), ^{
+		(void)QLPreviewPanel.sharedPreviewPanel;
+	});
 
 	[self showExifThumbnail:[u boolForKey:@"exifThumbnailShow"]
 			   shrinkWindow:NO];

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -149,9 +149,9 @@ static NSString *DYCharacterCountString(NSUInteger n) {
 // selected match); Tab / double-click completes; Esc cancels. Directories only.
 // Field editor that also pastes file URLs (e.g. a folder copied in Finder) as their POSIX
 // path, so ⌘V works like Finder's Go to Folder — not only plain-text paths.
-@interface DYPathFieldEditor : NSTextView
+@interface PathFieldEditor : NSTextView
 @end
-@implementation DYPathFieldEditor
+@implementation PathFieldEditor
 - (void)paste:(id)sender {
 	NSPasteboard *pb = NSPasteboard.generalPasteboard;
 	// a real file URL (e.g. a folder copied in Finder) → its POSIX path
@@ -170,12 +170,12 @@ static NSString *DYCharacterCountString(NSUInteger n) {
 }
 @end
 
-@interface DYGoToFolderController : NSObject <NSTextFieldDelegate, NSTableViewDataSource, NSTableViewDelegate, NSWindowDelegate>
+@interface GoToFolderController : NSObject <NSTextFieldDelegate, NSTableViewDataSource, NSTableViewDelegate, NSWindowDelegate>
 @end
-@implementation DYGoToFolderController {
+@implementation GoToFolderController {
 	NSWindow *_parent, *_sheet;
 	NSTextField *_field;
-	DYPathFieldEditor *_fieldEditor;
+	PathFieldEditor *_fieldEditor;
 	NSTableView *_table;
 	NSProgressIndicator *_spinner; // shown while a slow folder is scanned in the background
 	NSMutableArray<NSString *> *_matches;
@@ -192,7 +192,7 @@ static NSString *DYCharacterCountString(NSUInteger n) {
 static NSMutableArray *_dyGoToFolderLive; // keep controllers alive while their sheet is up
 
 + (void)presentForWindow:(NSWindow *)parent startingPath:(NSString *)start completion:(void(^)(NSString *))completion {
-	DYGoToFolderController *c = [[DYGoToFolderController alloc] init];
+	GoToFolderController *c = [[GoToFolderController alloc] init];
 	c->_parent = parent;
 	c->_completion = [completion copy];
 	c->_matches = [NSMutableArray array];
@@ -388,7 +388,7 @@ static NSMutableArray *_dyGoToFolderLive; // keep controllers alive while their 
 
 - (id)windowWillReturnFieldEditor:(NSWindow *)sender toObject:(id)client {
 	if (client != _field) return nil; // default editor for anything else
-	if (!_fieldEditor) { _fieldEditor = [[DYPathFieldEditor alloc] init]; _fieldEditor.fieldEditor = YES; }
+	if (!_fieldEditor) { _fieldEditor = [[PathFieldEditor alloc] init]; _fieldEditor.fieldEditor = YES; }
 	return _fieldEditor;
 }
 
@@ -2001,7 +2001,7 @@ enum {
 	// append a trailing slash (so the field lists the folder's contents) unless the path is
 	// already slash-terminated, e.g. root "/" — otherwise we'd produce "//"
 	NSString *start = wc.path.length ? ([abbrev hasSuffix:@"/"] ? abbrev : [abbrev stringByAppendingString:@"/"]) : @"~/";
-	[DYGoToFolderController presentForWindow:wc.window startingPath:start completion:^(NSString *chosen){
+	[GoToFolderController presentForWindow:wc.window startingPath:start completion:^(NSString *chosen){
 		if (chosen) [wc setPath:chosen];
 	}];
 }

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -146,9 +146,12 @@ static NSString *DYCharacterCountString(NSUInteger n) {
 	NSWindow *_parent, *_sheet;
 	NSTextField *_field;
 	NSTableView *_table;
+	NSProgressIndicator *_spinner; // shown while a slow folder is scanned in the background
 	NSMutableArray<NSString *> *_matches;
 	void (^_completion)(NSString *);
 	BOOL _userPickedRow; // YES once the user arrows/clicks a row, so Enter honors it
+	NSUInteger _scanToken; // bumped per scan so a stale background result can be discarded
+	BOOL _scanning;        // YES while the current scan is still running
 }
 static NSMutableArray *_dyGoToFolderLive; // keep controllers alive while their sheet is up
 
@@ -192,6 +195,11 @@ static NSMutableArray *_dyGoToFolderLive; // keep controllers alive while their 
 	_table.doubleAction = @selector(accept:);
 	sv.documentView = _table;
 	[cv addSubview:sv];
+
+	_spinner = [[NSProgressIndicator alloc] initWithFrame:NSMakeRect(NSMidX(sv.frame)-10, NSMidY(sv.frame)-10, 20, 20)];
+	_spinner.style = NSProgressIndicatorStyleSpinning;
+	_spinner.displayedWhenStopped = NO; // only visible while animating
+	[cv addSubview:_spinner];
 
 	NSButton *cancel = [NSButton buttonWithTitle:NSLocalizedString(@"Cancel", @"") target:self action:@selector(cancel:)];
 	cancel.frame = NSMakeRect(366, 12, 90, 32);
@@ -243,24 +251,40 @@ static NSMutableArray *_dyGoToFolderLive; // keep controllers alive while their 
 	else if ([raw hasSuffix:@"/"]) { dir = text; prefix = @""; }
 	else                           { dir = text.stringByDeletingLastPathComponent; prefix = text.lastPathComponent; }
 	_field.toolTip = text; // the field scrolls with the caret; show the full path on hover
-	[_matches removeAllObjects];
-	NSFileManager *fm = NSFileManager.defaultManager;
 	NSString *lp = prefix.lowercaseString;
 	BOOL showHidden = [prefix hasPrefix:@"."]; // reveal dot-folders once the user types a dot
-	for (NSString *name in [fm contentsOfDirectoryAtPath:dir error:NULL]) {
-		if (!showHidden && [name hasPrefix:@"."]) continue;
-		if (lp.length && ![name.lowercaseString hasPrefix:lp]) continue;
-		NSString *full = [dir stringByAppendingPathComponent:name];
-		BOOL isDir;
-		if ([fm fileExistsAtPath:full isDirectory:&isDir] && isDir)
-			[_matches addObject:full];
-	}
-	[_matches sortUsingComparator:^NSComparisonResult(NSString *a, NSString *b){
-		return [a.lastPathComponent localizedStandardCompare:b.lastPathComponent];
-	}];
-	[_table reloadData];
-	if (_matches.count)
-		[_table selectRowIndexes:[NSIndexSet indexSetWithIndex:0] byExtendingSelection:NO];
+	// Scan in the background: a folder with many entries needs a stat() per item, which
+	// would otherwise freeze the sheet. A token discards results from superseded scans.
+	NSUInteger token = ++_scanToken;
+	_scanning = YES;
+	// only reveal the spinner if the scan is slow enough to notice, so typing doesn't flash it
+	dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.15 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+		if (self->_scanning && token == self->_scanToken) [self->_spinner startAnimation:nil];
+	});
+	dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+		NSFileManager *fm = [[NSFileManager alloc] init]; // a private instance is thread-safe
+		NSMutableArray<NSString *> *found = [NSMutableArray array];
+		for (NSString *name in [fm contentsOfDirectoryAtPath:dir error:NULL]) {
+			if (!showHidden && [name hasPrefix:@"."]) continue;
+			if (lp.length && ![name.lowercaseString hasPrefix:lp]) continue;
+			NSString *full = [dir stringByAppendingPathComponent:name];
+			BOOL isDir;
+			if ([fm fileExistsAtPath:full isDirectory:&isDir] && isDir)
+				[found addObject:full];
+		}
+		[found sortUsingComparator:^NSComparisonResult(NSString *a, NSString *b){
+			return [a.lastPathComponent localizedStandardCompare:b.lastPathComponent];
+		}];
+		dispatch_async(dispatch_get_main_queue(), ^{
+			if (token != self->_scanToken) return; // a newer scan superseded this one
+			self->_scanning = NO;
+			[self->_spinner stopAnimation:nil];
+			[self->_matches setArray:found];
+			[self->_table reloadData];
+			if (self->_matches.count)
+				[self->_table selectRowIndexes:[NSIndexSet indexSetWithIndex:0] byExtendingSelection:NO];
+		});
+	});
 }
 
 - (void)moveSelectionBy:(NSInteger)delta {

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -1300,6 +1300,9 @@ enum {
 
 
 - (BOOL)validateMenuItem:(NSMenuItem *)menuItem {
+	// Preferences carries a tag only so it can be rebound; it's always available,
+	// so validate it by action rather than falling into the tag-based gates below.
+	if (menuItem.action == @selector(openPrefWin:)) return YES;
 	NSInteger t = menuItem.tag;
 	NSInteger test_t = t;
 	if (!NSApp.mainWindow) {

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -621,8 +621,8 @@ static NSModalResponse DYRunAlert(NSAlert *alert) {
 			return;
 		}
 	}
-	BOOL fullscreen = [NSUserDefaults.standardUserDefaults integerForKey:@"slideshowDefaultMode"] == 0;
-	if (NSApp.currentEvent.modifierFlags & NSEventModifierFlagOption) fullscreen = !fullscreen;
+	// double-click (or Enter) opens a windowed slideshow; hold Option for full screen
+	BOOL fullscreen = (NSApp.currentEvent.modifierFlags & NSEventModifierFlagOption) != 0;
 	[self startSlideshowFullscreen:fullscreen];
 }
 

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -135,6 +135,13 @@ CGFloat DYInterfaceTextScale(void) {
 	}
 }
 
+// Run an alert with no window animation, so it pops open instantly instead of
+// fading/scaling in.
+static NSModalResponse DYRunAlert(NSAlert *alert) {
+	alert.window.animationBehavior = NSWindowAnimationBehaviorNone;
+	return [alert runModal];
+}
+
 @interface CreeveyController () <NSMenuItemValidation>
 @property (nonatomic) BOOL appDidFinishLaunching;
 @property (nonatomic) BOOL filesWereOpenedAtLaunch;
@@ -412,7 +419,7 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 		NSAlert *alert = [[NSAlert alloc] init];
 		alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"Could not set the desktop because an error occurred. %@", @""), error.localizedDescription];
 		[alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"")];
-		[alert runModal];
+		DYRunAlert(alert);
 	};
 }
 
@@ -445,7 +452,7 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 		alert.informativeText = NSLocalizedString(@"This operation cannot be undone! Are you sure you want to continue?", @"");
 		[alert addButtonWithTitle:NSLocalizedString(@"Continue", @"")];
 		[alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"")];
-		NSModalResponse response = [alert runModal];
+		NSModalResponse response = DYRunAlert(alert);
 		if (response != NSAlertFirstButtonReturn)
 			return; // user cancelled
 		jinfo.preserveModificationDate = jinfo.resetOrientation ? [NSUserDefaults.standardUserDefaults boolForKey:@"jpegPreserveModDate"]
@@ -578,7 +585,7 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 		} else {
 			alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"%lu files could not be moved because of an error.",@""), notMoved.count];
 		}
-		[alert runModal];
+		DYRunAlert(alert);
 	}
 	_originalPaths = [paths copy];
 	_movedUrls = [moved copy];
@@ -605,7 +612,7 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 			alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"The file “%@” could not be copied because of an error: %@", @""), notCopied[0].lastPathComponent, err.localizedDescription];
 		else
 			alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"%lu files could not be copied because of an error.", @""), notCopied.count];
-		[alert runModal];
+		DYRunAlert(alert);
 	}
 }
 
@@ -613,6 +620,7 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 	NSOpenPanel *op = [NSOpenPanel openPanel];
 	op.canChooseFiles = NO;
 	op.canChooseDirectories = YES;
+	op.animationBehavior = NSWindowAnimationBehaviorNone;
 	if ([op runModal] != NSModalResponseOK) return;
 	NSURL *dest = op.URL;
 	[self moveSelectedFilesTo:dest];
@@ -630,6 +638,7 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 	NSOpenPanel *op = [NSOpenPanel openPanel];
 	op.canChooseFiles = NO;
 	op.canChooseDirectories = YES;
+	op.animationBehavior = NSWindowAnimationBehaviorNone;
 	if ([op runModal] != NSModalResponseOK) return;
 	NSURL *dest = op.URL;
 	[self copySelectedFilesTo:dest];
@@ -660,7 +669,7 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 	deleteButton.hasDestructiveAction = YES;
 	if (numFiles > 1)
 		[alert addButtonWithTitle:NSLocalizedString(@"Skip", @"after move to trash failed")];
-	NSModalResponse response = [alert runModal];
+	NSModalResponse response = DYRunAlert(alert);
 	if (response == NSAlertFirstButtonReturn)
 		return 2;
 	if (response == NSAlertSecondButtonReturn) {
@@ -670,7 +679,7 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 		}
 		alert = [[NSAlert alloc] init];
 		alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"The file %@ could not be deleted because an error occurred: %@", @""), fullpath.lastPathComponent, error.localizedDescription];
-		[alert runModal];
+		DYRunAlert(alert);
 	}
 	return 0;
 }
@@ -704,7 +713,7 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 					} else {
 						NSAlert *alert = [[NSAlert alloc] init];
 						alert.informativeText = [NSString stringWithFormat:doTrash ? NSLocalizedString(@"The file \"%@\" could not be restored from the trash because of an error: %@", @"") : NSLocalizedString(@"The file “%@” could not be moved because of an error: %@", @""), s.lastPathComponent, err.localizedDescription];
-						[alert runModal];
+						DYRunAlert(alert);
 					}
 				}];
 				[um setActionName:[NSString stringWithFormat:doTrash ? NSLocalizedString(@"Move to Trash",@"") : NSLocalizedString(@"Move File",@"for undo")]];
@@ -745,7 +754,7 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 				if (moved.count < n) {
 					NSAlert *alert = [[NSAlert alloc] init];
 					alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"%lu file(s) could not be restored from the trash because of an error. You should probably check your Trash.",@""), n-moved.count];
-					[alert runModal];
+					DYRunAlert(alert);
 				}
 			}];
 			[um setActionName:[NSString stringWithFormat:NSLocalizedString(@"Move to Trash (%lu File(s))",@"for undo"), n]];
@@ -772,7 +781,7 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 					if (moved.count < n) {
 						NSAlert *alert = [[NSAlert alloc] init];
 						alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"%lu file(s) could not be moved back because of an error.",@""), n-moved.count];
-						[alert runModal];
+						DYRunAlert(alert);
 					}
 				}];
 				[um setActionName:[NSString stringWithFormat:NSLocalizedString(@"Move Files (%lu File(s))",@"for undo"), n]];
@@ -816,7 +825,7 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 	[alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"")];
 	NSButton *deleteButton = [alert addButtonWithTitle:NSLocalizedString(@"Delete", @"Delete Immediately Button")];
 	deleteButton.hasDestructiveAction = YES;
-	if ([alert runModal] != NSAlertSecondButtonReturn)
+	if (DYRunAlert(alert) != NSAlertSecondButtonReturn)
 		return;
 
 	BOOL slideshowMain = slidesWindow.isMainWindow;
@@ -840,7 +849,7 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 		alert.informativeText = notDeleted.count == 1
 			? [NSString stringWithFormat:NSLocalizedString(@"The file “%@” could not be deleted because an error occurred.", @""), [notDeleted[0] lastPathComponent]]
 			: [NSString stringWithFormat:NSLocalizedString(@"%lu file(s) could not be deleted because an error occurred.", @""), (unsigned long)notDeleted.count];
-		[alert runModal];
+		DYRunAlert(alert);
 	}
 	if (!slideshowMain) {
 		[frontWindow updateExifInfo];
@@ -957,7 +966,7 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 	[alert addButtonWithTitle:NSLocalizedString(@"Rename", @"")];
 	[alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"")];
 	alert.window.initialFirstResponder = input;
-	if ([alert runModal] != NSAlertFirstButtonReturn) {
+	if (DYRunAlert(alert) != NSAlertFirstButtonReturn) {
 		// cancelled: keep the same image selected in the browser
 		if (!slidesWindow.isMainWindow)
 			[frontWindow.window makeFirstResponder:frontWindow.imageMatrix];
@@ -971,14 +980,14 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 	if ([newName containsString:@"/"] || [newName hasPrefix:@"."]) {
 		alert = [[NSAlert alloc] init];
 		alert.informativeText = NSLocalizedString(@"File names cannot contain “/” or begin with a period.", @"");
-		[alert runModal];
+		DYRunAlert(alert);
 		return;
 	}
 	NSString *newPath = [oldPath.stringByDeletingLastPathComponent stringByAppendingPathComponent:newName];
 	if ([NSFileManager.defaultManager fileExistsAtPath:newPath]) {
 		alert = [[NSAlert alloc] init];
 		alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"An item named “%@” already exists in this location.", @""), newName];
-		[alert runModal];
+		DYRunAlert(alert);
 		return;
 	}
 
@@ -1005,7 +1014,7 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 	if (![NSFileManager.defaultManager moveItemAtPath:oldPath toPath:newPath error:&err]) {
 		NSAlert *alert = [[NSAlert alloc] init];
 		alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"The file “%@” could not be renamed because of an error: %@", @""), oldPath.lastPathComponent, err.localizedDescription];
-		[alert runModal];
+		DYRunAlert(alert);
 		return;
 	}
 	[self fileWasRenamedFrom:oldPath to:newPath];

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -1671,7 +1671,15 @@ enum {
 }
 
 - (IBAction)openAboutPanel:(id)sender {
-	[NSApp orderFrontStandardAboutPanelWithOptions:@{@"ApplicationIcon": [NSImage imageNamed:@"logo"]}];
+	NSMutableDictionary *opts = [@{NSAboutPanelOptionApplicationIcon: [NSImage imageNamed:@"logo"]} mutableCopy];
+	// append the short git commit hash (stamped into GitInfo.plist at build time) to the build number
+	NSBundle *b = NSBundle.mainBundle;
+	NSURL *gitInfoURL = [b URLForResource:@"GitInfo" withExtension:@"plist"];
+	NSString *hash = gitInfoURL ? [NSDictionary dictionaryWithContentsOfURL:gitInfoURL][@"GitCommitHash"] : nil;
+	NSString *build = [b objectForInfoDictionaryKey:@"CFBundleVersion"];
+	if (hash.length && build.length)
+		opts[NSAboutPanelOptionVersion] = [NSString stringWithFormat:@"%@ · %@", build, hash];
+	[NSApp orderFrontStandardAboutPanelWithOptions:opts];
 }
 
 #pragma mark configuration

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -476,6 +476,7 @@ static NSModalResponse DYRunAlert(NSAlert *alert) {
 
 	NSMutableArray<NSDictionary *> *_recentFolders; // Open Recent: in-memory, most-recent-first
 	BOOL _recentFoldersDirty;                        // unsaved changes since last flush
+	NSMenu *_moveRecentMenu, *_copyRecentMenu;       // File ▸ Move/Copy To Recent submenus
 
 	DYImageCache *thumbsCache;
 	
@@ -535,7 +536,9 @@ static NSModalResponse DYRunAlert(NSAlert *alert) {
 		@"interfaceTextCustomSize":@13, // point size when interfaceTextSize == 3 (custom)
 		@"copyPathnameShellQuoted":@YES, // Copy as Pathname: YES = shell-quoted, NO = Finder-style raw
 		@"recentFolders":@[],            // Open Recent list (array of state dicts, most-recent-first)
-		@"recentFoldersMax":@10,         // how many recent folders to remember
+		@"recentFoldersMax":@10,         // how many recent paths to keep (Open Recent + Move/Copy To Recent)
+		@"recentMoveToFolders":@[],      // Move To Recent: recent destination folders, most-recent-first
+		@"recentCopyToFolders":@[],      // Copy To Recent: recent destination folders, most-recent-first
 	}];
 
 	[NSValueTransformer setValueTransformer:[[TimeIntervalPlusWeekToStringTransformer alloc] init]
@@ -601,8 +604,7 @@ static NSModalResponse DYRunAlert(NSAlert *alert) {
 	for (NSString *type in disabledFiletypes) {
 		[filetypes removeObject:type];
 	}
-	[self updateMoveToMenuItem];
-	[self updateCopyToMenuItem];
+	[self setupRecentDestinationMenus];
 	[self updateAlternateSlideshowMenuItem];
 	[self updateAppearance];
 	
@@ -1027,22 +1029,91 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 	[NSApp stopModal];
 }
 
-- (void)updateMoveToMenuItem {
-	NSString *path = [NSUserDefaults.standardUserDefaults stringForKey:@"lastUsedMoveToFolder"];
-	if (path == nil) return;
-	NSMenu *m = [NSApp.mainMenu itemWithTag:FILE_MENU].submenu;
-	NSMenuItem *item = [m itemWithTag:MOVE_TO_AGAIN];
-	NSString *name = [NSFileManager.defaultManager displayNameAtPath:path];
-	item.title = [NSString stringWithFormat:NSLocalizedString(@"Move to “%@” Again", @"File menu"), name];
+#pragma mark Move/Copy To Recent (submenus of recent destination folders)
+
+// Number of recent items to keep — shared with Open Recent (Preferences ▸ "Recent paths to keep").
+- (NSInteger)recentItemsMax {
+	return MAX(1, [NSUserDefaults.standardUserDefaults integerForKey:@"recentFoldersMax"]);
 }
 
-- (void)updateCopyToMenuItem {
-	NSString *path = [NSUserDefaults.standardUserDefaults stringForKey:@"lastUsedCopyToFolder"];
-	if (path == nil) return;
-	NSMenu *m = [NSApp.mainMenu itemWithTag:FILE_MENU].submenu;
-	NSMenuItem *item = [m itemWithTag:COPY_TO_AGAIN];
-	NSString *name = [NSFileManager.defaultManager displayNameAtPath:path];
-	item.title = [NSString stringWithFormat:NSLocalizedString(@"Copy to “%@” Again", @"File menu"), name];
+- (NSArray<NSString *> *)recentDestinationsForKey:(NSString *)key {
+	return [NSUserDefaults.standardUserDefaults arrayForKey:key] ?: @[];
+}
+
+// Push a destination to the top of a recent list (dedup, cap at recentItemsMax), mirror it to the
+// single "last used" default (used for validation), and rebuild the submenus.
+- (void)recordRecentDestination:(NSString *)path listKey:(NSString *)listKey lastKey:(NSString *)lastKey {
+	if (path.length == 0) return;
+	NSMutableArray<NSString *> *list = [[self recentDestinationsForKey:listKey] mutableCopy];
+	[list removeObject:path];
+	[list insertObject:path atIndex:0];
+	while ((NSInteger)list.count > self.recentItemsMax) [list removeLastObject];
+	NSUserDefaults *u = NSUserDefaults.standardUserDefaults;
+	[u setObject:list forKey:listKey];
+	[u setObject:path forKey:lastKey];
+	[self rebuildRecentDestinationMenus];
+}
+- (void)recordRecentMoveDestination:(NSString *)path { [self recordRecentDestination:path listKey:@"recentMoveToFolders" lastKey:@"lastUsedMoveToFolder"]; }
+- (void)recordRecentCopyDestination:(NSString *)path { [self recordRecentDestination:path listKey:@"recentCopyToFolders" lastKey:@"lastUsedCopyToFolder"]; }
+
+// Attach fresh submenus to the "Move To Recent" / "Copy To Recent" items (called once at launch).
+- (void)setupRecentDestinationMenus {
+	NSMenu *file = [NSApp.mainMenu itemWithTag:FILE_MENU].submenu;
+	NSMenuItem *mv = [file itemWithTag:MOVE_TO_AGAIN], *cp = [file itemWithTag:COPY_TO_AGAIN];
+	_moveRecentMenu = [[NSMenu alloc] initWithTitle:mv.title]; _moveRecentMenu.autoenablesItems = NO;
+	_copyRecentMenu = [[NSMenu alloc] initWithTitle:cp.title]; _copyRecentMenu.autoenablesItems = NO;
+	mv.submenu = _moveRecentMenu;
+	cp.submenu = _copyRecentMenu;
+	[self rebuildRecentDestinationMenus];
+}
+
+- (void)rebuildRecentDestinationMenus {
+	[self fillRecentMenu:_moveRecentMenu listKey:@"recentMoveToFolders" action:@selector(moveToRecentFolder:) shortcut:@"m"];
+	[self fillRecentMenu:_copyRecentMenu listKey:@"recentCopyToFolders" action:@selector(copyToRecentFolder:) shortcut:@"c"];
+}
+
+// Fill one recent-destination submenu. The most-recent item carries the original ⌃⌘M / ⌃⌘C shortcut
+// so it still repeats the last destination. Built eagerly (not on open) so the shortcut stays live.
+- (void)fillRecentMenu:(NSMenu *)menu listKey:(NSString *)listKey action:(SEL)action shortcut:(NSString *)shortcut {
+	if (!menu) return;
+	[menu removeAllItems];
+	NSArray<NSString *> *list = [self recentDestinationsForKey:listKey];
+	if (list.count == 0) {
+		NSMenuItem *none = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"None", @"") action:NULL keyEquivalent:@""];
+		none.enabled = NO;
+		[menu addItem:none];
+		return;
+	}
+	NSFileManager *fm = NSFileManager.defaultManager;
+	NSUInteger i = 0;
+	for (NSString *path in list) {
+		if ((NSInteger)i >= self.recentItemsMax) break; // already capped, but stay safe if max shrank
+		NSMenuItem *mi = [[NSMenuItem alloc] initWithTitle:path.stringByAbbreviatingWithTildeInPath
+													action:action keyEquivalent:(i == 0 ? shortcut : @"")];
+		if (i == 0) mi.keyEquivalentModifierMask = NSEventModifierFlagControl | NSEventModifierFlagCommand;
+		mi.target = self;
+		mi.representedObject = path;
+		mi.enabled = [fm fileExistsAtPath:path]; // grey out folders that no longer exist
+		NSImage *icon = [NSWorkspace.sharedWorkspace iconForFile:path];
+		icon.size = NSMakeSize(16, 16);
+		mi.image = icon;
+		[menu addItem:mi];
+		i++;
+	}
+}
+
+- (IBAction)moveToRecentFolder:(NSMenuItem *)sender {
+	NSString *path = sender.representedObject;
+	if (![path isKindOfClass:NSString.class]) return;
+	[self moveSelectedFilesTo:[NSURL fileURLWithPath:path isDirectory:YES]];
+	[self recordRecentMoveDestination:path]; // bump to the top
+}
+
+- (IBAction)copyToRecentFolder:(NSMenuItem *)sender {
+	NSString *path = sender.representedObject;
+	if (![path isKindOfClass:NSString.class]) return;
+	[self copySelectedFilesTo:[NSURL fileURLWithPath:path isDirectory:YES]];
+	[self recordRecentCopyDestination:path];
 }
 
 - (void)updateAlternateSlideshowMenuItem {
@@ -1116,14 +1187,7 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 	if ([op runModal] != NSModalResponseOK) return;
 	NSURL *dest = op.URL;
 	[self moveSelectedFilesTo:dest];
-	[NSUserDefaults.standardUserDefaults setObject:dest.path forKey:@"lastUsedMoveToFolder"];
-	[self updateMoveToMenuItem];
-}
-
-- (IBAction)moveSelectedFilesAgain:(id)sender {
-	NSString *folder = [NSUserDefaults.standardUserDefaults stringForKey:@"lastUsedMoveToFolder"];
-	NSURL *dest = [NSURL fileURLWithPath:folder isDirectory:YES];
-	[self moveSelectedFilesTo:dest];
+	[self recordRecentMoveDestination:dest.path];
 }
 
 - (IBAction)copySelectedFiles:(id)sender {
@@ -1134,14 +1198,7 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 	if ([op runModal] != NSModalResponseOK) return;
 	NSURL *dest = op.URL;
 	[self copySelectedFilesTo:dest];
-	[NSUserDefaults.standardUserDefaults setObject:dest.path forKey:@"lastUsedCopyToFolder"];
-	[self updateCopyToMenuItem];
-}
-
-- (IBAction)copySelectedFilesAgain:(id)sender {
-	NSString *folder = [NSUserDefaults.standardUserDefaults stringForKey:@"lastUsedCopyToFolder"];
-	NSURL *dest = [NSURL fileURLWithPath:folder isDirectory:YES];
-	[self copySelectedFilesTo:dest];
+	[self recordRecentCopyDestination:dest.path];
 }
 
 
@@ -1836,8 +1893,9 @@ enum {
 				: numSelected > 0 && frontWindow && frontWindow.currentFilesDeletable;
 			if (!writable) return NO;
 			if (test_t != JPEG_OP) {
-				if (t == MOVE_TO_AGAIN) return [NSUserDefaults.standardUserDefaults stringForKey:@"lastUsedMoveToFolder"] != nil;
-				if (t == COPY_TO_AGAIN) return [NSUserDefaults.standardUserDefaults stringForKey:@"lastUsedCopyToFolder"] != nil;
+				// Move/Copy To Recent (submenu parents): enable only when the recent list isn't empty.
+				if (t == MOVE_TO_AGAIN) return [self recentDestinationsForKey:@"recentMoveToFolders"].count > 0;
+				if (t == COPY_TO_AGAIN) return [self recentDestinationsForKey:@"recentCopyToFolders"].count > 0;
 				return YES;
 			}
 			isjpeg = slidesWindow.isMainWindow

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -125,8 +125,8 @@ static NSString *DYCharacterCountString(NSUInteger n) {
 
 CGFloat DYInterfaceTextScale(void) {
 	switch ([NSUserDefaults.standardUserDefaults integerForKey:@"interfaceTextSize"]) {
-		case 1:  return 1.25;
-		case 2:  return 1.5;
+		case 1:  return 1.2;
+		case 2:  return 1.4;
 		default: return 1.0;
 	}
 }

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -147,11 +147,35 @@ static NSString *DYCharacterCountString(NSUInteger n) {
 // A Finder-style "Go to the folder:" sheet: a path field with ~ expansion and a
 // list of matching sub-folders below. Enter goes to the typed path (or the
 // selected match); Tab / double-click completes; Esc cancels. Directories only.
-@interface DYGoToFolderController : NSObject <NSTextFieldDelegate, NSTableViewDataSource, NSTableViewDelegate>
+// Field editor that also pastes file URLs (e.g. a folder copied in Finder) as their POSIX
+// path, so ⌘V works like Finder's Go to Folder — not only plain-text paths.
+@interface DYPathFieldEditor : NSTextView
+@end
+@implementation DYPathFieldEditor
+- (void)paste:(id)sender {
+	NSPasteboard *pb = NSPasteboard.generalPasteboard;
+	// a real file URL (e.g. a folder copied in Finder) → its POSIX path
+	NSArray<NSURL *> *urls = [pb readObjectsForClasses:@[NSURL.class]
+		options:@{NSPasteboardURLReadingFileURLsOnlyKey:@YES}];
+	NSString *p = urls.firstObject.path;
+	if (p.length) { [self insertText:p replacementRange:self.selectedRange]; return; }
+	// plain-text path (e.g. `pwd | pbcopy`) → insert as-is, minus stray newlines
+	NSString *s = [pb stringForType:NSPasteboardTypeString];
+	if (s.length) {
+		s = [s stringByTrimmingCharactersInSet:NSCharacterSet.newlineCharacterSet];
+		[self insertText:s replacementRange:self.selectedRange];
+		return;
+	}
+	[super paste:sender];
+}
+@end
+
+@interface DYGoToFolderController : NSObject <NSTextFieldDelegate, NSTableViewDataSource, NSTableViewDelegate, NSWindowDelegate>
 @end
 @implementation DYGoToFolderController {
 	NSWindow *_parent, *_sheet;
 	NSTextField *_field;
+	DYPathFieldEditor *_fieldEditor;
 	NSTableView *_table;
 	NSProgressIndicator *_spinner; // shown while a slow folder is scanned in the background
 	NSMutableArray<NSString *> *_matches;
@@ -176,6 +200,7 @@ static NSMutableArray *_dyGoToFolderLive; // keep controllers alive while their 
 
 	_sheet = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 560, 300)
 										 styleMask:NSWindowStyleMaskTitled backing:NSBackingStoreBuffered defer:NO];
+	_sheet.delegate = self; // for windowWillReturnFieldEditor:toObject:
 	NSView *cv = _sheet.contentView;
 
 	NSTextField *label = [NSTextField labelWithString:NSLocalizedString(@"Go to the folder:", @"")];
@@ -314,6 +339,12 @@ static NSMutableArray *_dyGoToFolderLive; // keep controllers alive while their 
 }
 
 - (void)rowClicked:(id)sender { _userPickedRow = YES; }
+
+- (id)windowWillReturnFieldEditor:(NSWindow *)sender toObject:(id)client {
+	if (client != _field) return nil; // default editor for anything else
+	if (!_fieldEditor) { _fieldEditor = [[DYPathFieldEditor alloc] init]; _fieldEditor.fieldEditor = YES; }
+	return _fieldEditor;
+}
 
 - (void)controlTextDidChange:(NSNotification *)n { _userPickedRow = NO; [self updateMatches]; }
 

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -1696,6 +1696,10 @@ enum {
 	COPY_PATHNAME = 28,
 	SEARCH = 29,
 	SUBFOLDERS = 30,
+	ZOOM_IN = 31,
+	ZOOM_OUT = 32,
+	ZOOM_ACTUAL = 32+1,
+	ZOOM_FIT = 32+2,
 	JPEG_OP = 100,
 	ROTATE_L = 107,
 	ROTATE_R = 105,
@@ -1717,6 +1721,13 @@ enum {
 	FILE_MENU = 300,
 };
 
+
+// View ▸ Zoom menu commands (⌘+ / ⌘− / ⌘0 / ⌘9). Forward to the slideshow; validateMenuItem:
+// keeps them enabled only while a slideshow image is showing.
+- (IBAction)zoomIn:(id)sender          { [slidesWindow performSlideshowAction:SlideshowActionZoomIn]; }
+- (IBAction)zoomOut:(id)sender         { [slidesWindow performSlideshowAction:SlideshowActionZoomOut]; }
+- (IBAction)zoomActualSize:(id)sender  { [slidesWindow performSlideshowAction:SlideshowActionActualSize]; }
+- (IBAction)zoomFitToWindow:(id)sender { [slidesWindow performSlideshowAction:SlideshowActionResetView]; }
 
 - (BOOL)validateMenuItem:(NSMenuItem *)menuItem {
 	// Preferences carries a tag only so it can be rebound; it's always available,
@@ -1787,6 +1798,12 @@ enum {
 			// so it won't hijack SPACE in the slideshow, Prefs, or text fields
 			if (slidesWindow.isMainWindow) return NO;
 			return numSelected > 0 && frontWindow && frontWindow.window.isMainWindow && frontWindow.filenamesDone;
+		case ZOOM_IN:
+		case ZOOM_OUT:
+		case ZOOM_ACTUAL:
+		case ZOOM_FIT:
+			// image zoom is a slideshow-only command
+			return slidesWindow.isMainWindow && slidesWindow.currentImageLoaded;
 		case GO_TO_FOLDER:
 			return !slidesWindow.isMainWindow && frontWindow != nil;
 		case SEARCH:

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -7,6 +7,7 @@
 
 @import UniformTypeIdentifiers;
 #import "CreeveyController.h"
+#import <objc/runtime.h>
 #import "DYJpegtran.h"
 #import "DYCarbonGoodies.h"
 
@@ -93,6 +94,30 @@ NSMutableAttributedString* Fileinfo2EXIFString(NSString *origPath, DYImageCache 
 @implementation DYColorToDataTransformer
 + (NSArray<Class> *)allowedTopLevelClasses {
 	return [[super allowedTopLevelClasses] arrayByAddingObject:[NSColor class]];
+}
+@end
+
+static NSString *DYCharacterCountString(NSUInteger n) {
+	return [NSString stringWithFormat:(n == 1 ? NSLocalizedString(@"%lu character", @"")
+											  : NSLocalizedString(@"%lu characters", @"")), (unsigned long)n];
+}
+
+// Return/Enter in the multi-line rename field confirms the dialog (clicks "Rename")
+// instead of inserting a newline, and the character count updates as the user types.
+@interface DYRenameFieldDelegate : NSObject <NSTextViewDelegate>
+@property (weak) NSAlert *alert;
+@property (weak) NSTextField *countLabel;
+@end
+@implementation DYRenameFieldDelegate
+- (BOOL)textView:(NSTextView *)textView doCommandBySelector:(SEL)commandSelector {
+	if (commandSelector == @selector(insertNewline:)) {
+		[self.alert.buttons.firstObject performClick:nil];
+		return YES;
+	}
+	return NO;
+}
+- (void)textDidChange:(NSNotification *)notification {
+	self.countLabel.stringValue = DYCharacterCountString([[notification.object string] length]);
 }
 @end
 
@@ -739,6 +764,232 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 	[self removePicsAndTrash:YES];
 }
 
+// permanently delete the selected file(s), bypassing the trash. This cannot be undone,
+// so we always ask for confirmation first.
+- (IBAction)deleteSelectedFilesPermanently:(id)sender {
+	NSArray *files;
+	if (slidesWindow.isMainWindow) {
+		NSString *s = slidesWindow.currentFile;
+		files = s ? @[s] : @[];
+	} else {
+		files = frontWindow.currentSelection;
+	}
+	NSUInteger n = files.count;
+	if (n == 0) {
+		NSBeep();
+		return;
+	}
+
+	NSAlert *alert = [[NSAlert alloc] init];
+	alert.messageText = n == 1
+		? [NSString stringWithFormat:NSLocalizedString(@"Are you sure you want to permanently delete “%@”?", @""), [files[0] lastPathComponent]]
+		: [NSString stringWithFormat:NSLocalizedString(@"Are you sure you want to permanently delete these %lu items?", @""), (unsigned long)n];
+	alert.informativeText = NSLocalizedString(@"This operation cannot be undone.", @"");
+	if (n == 1)
+		alert.icon = [thumbsCache imageForKey:ResolveAliasToPath(files[0])];
+	[alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"")];
+	NSButton *deleteButton = [alert addButtonWithTitle:NSLocalizedString(@"Delete", @"Delete Immediately Button")];
+	deleteButton.hasDestructiveAction = YES;
+	if ([alert runModal] != NSAlertSecondButtonReturn)
+		return;
+
+	BOOL slideshowMain = slidesWindow.isMainWindow;
+	NSUInteger oldIndex = slideshowMain ? NSNotFound : frontWindow.selectedIndexes.firstIndex;
+	NSMutableArray<NSString *> *notDeleted = [NSMutableArray array];
+	for (NSString *fullpath in files) {
+		NSURL *url = [NSURL fileURLWithPath:fullpath isDirectory:NO];
+		NSError * __autoreleasing error = nil;
+		if ([NSFileManager.defaultManager removeItemAtURL:url error:&error]) {
+			if (!IsAliasFilePath(fullpath))
+				[thumbsCache removeImageForKey:fullpath];
+			[creeveyWindows makeObjectsPerformSelector:@selector(fileWasDeleted:) withObject:fullpath];
+			if (slidesWindow.visible)
+				[slidesWindow removeImageForFile:fullpath];
+		} else {
+			[notDeleted addObject:fullpath];
+		}
+	}
+	if (notDeleted.count) {
+		alert = [[NSAlert alloc] init];
+		alert.informativeText = notDeleted.count == 1
+			? [NSString stringWithFormat:NSLocalizedString(@"The file “%@” could not be deleted because an error occurred.", @""), [notDeleted[0] lastPathComponent]]
+			: [NSString stringWithFormat:NSLocalizedString(@"%lu file(s) could not be deleted because an error occurred.", @""), (unsigned long)notDeleted.count];
+		[alert runModal];
+	}
+	if (!slideshowMain) {
+		[frontWindow updateExifInfo];
+		// no selection means all files were successfully deleted; select the next image if possible
+		if (frontWindow.selectedIndexes.firstIndex == NSNotFound && oldIndex != NSNotFound && oldIndex < frontWindow.displayedFilenames.count)
+			[frontWindow selectIndex:oldIndex];
+	}
+}
+
+// rename the single selected file. Undoable.
+- (IBAction)renameSelectedFile:(id)sender {
+	NSString *oldPath;
+	if (slidesWindow.isMainWindow) {
+		oldPath = slidesWindow.currentFile;
+	} else {
+		NSArray *sel = frontWindow.currentSelection;
+		if (sel.count != 1) {
+			NSBeep();
+			return;
+		}
+		oldPath = sel[0];
+	}
+	if (oldPath == nil) {
+		NSBeep();
+		return;
+	}
+
+	NSString *oldName = oldPath.lastPathComponent;
+	NSAlert *alert = [[NSAlert alloc] init];
+	alert.messageText = NSLocalizedString(@"Rename File", @"");
+	// keep the message constant (the current name is shown in the field below) so it
+	// stays one line no matter how long the file name is
+	alert.informativeText = NSLocalizedString(@"Enter a new name for this file.", @"");
+	alert.icon = [thumbsCache imageForKey:ResolveAliasToPath(oldPath)];
+	// Word-wrapping field, fixed width, whose height grows to show the ENTIRE name so
+	// nothing is ever hidden, plus a live character count so the true length is always
+	// explicit — before and after editing.
+	CGFloat width = 340;
+	NSFont *font = [NSFont systemFontOfSize:NSFont.systemFontSize];
+	NSSize inset = NSMakeSize(4, 3);
+	NSScrollView *sv = [[NSScrollView alloc] initWithFrame:NSMakeRect(0, 0, width, 54)];
+	sv.borderType = NSBezelBorder;
+	sv.hasVerticalScroller = YES;
+	NSSize probeContent = [NSScrollView contentSizeForFrameSize:NSMakeSize(width, 54)
+										horizontalScrollerClass:Nil verticalScrollerClass:Nil
+													 borderType:NSBezelBorder controlSize:NSControlSizeRegular
+												  scrollerStyle:NSScrollerStyleOverlay];
+	CGFloat contentWidth = probeContent.width;
+	CGFloat borderChrome = 54 - probeContent.height; // frame height beyond the text area
+
+	NSTextView *input = [[NSTextView alloc] initWithFrame:NSMakeRect(0, 0, contentWidth, 54)];
+	input.font = font;
+	input.richText = NO;
+	// never let macOS "helpfully" rewrite a file name
+	input.automaticQuoteSubstitutionEnabled = NO;
+	input.automaticDashSubstitutionEnabled = NO;
+	input.automaticTextReplacementEnabled = NO;
+	input.automaticSpellingCorrectionEnabled = NO;
+	input.textContainerInset = inset;
+	input.minSize = NSMakeSize(0, 0);
+	input.maxSize = NSMakeSize(FLT_MAX, FLT_MAX);
+	input.verticallyResizable = YES;
+	input.horizontallyResizable = NO;
+	input.textContainer.widthTracksTextView = YES;
+	input.textContainer.size = NSMakeSize(contentWidth, FLT_MAX);
+	input.string = oldName;
+
+	// count the ACTUAL wrapped lines at the display width (line fragments, not a rounded
+	// height) and grow the box to show them all, bounded to ~1/3 of the screen
+	NSLayoutManager *lm = input.layoutManager;
+	NSTextContainer *tc = input.textContainer;
+	[lm ensureLayoutForTextContainer:tc];
+	CGFloat lineHeight = [lm defaultLineHeightForFont:font];
+	NSUInteger numLines = 0, glyphIndex = 0, glyphCount = lm.numberOfGlyphs;
+	while (glyphIndex < glyphCount) {
+		NSRange lineRange;
+		[lm lineFragmentRectForGlyphAtIndex:glyphIndex effectiveRange:&lineRange];
+		glyphIndex = NSMaxRange(lineRange);
+		++numLines;
+	}
+	CGFloat screenAvail = (NSScreen.mainScreen ? NSScreen.mainScreen.visibleFrame.size.height : 800) / 3.0;
+	NSUInteger maxRows = MAX((NSUInteger)1, (NSUInteger)floor(screenAvail / lineHeight));
+	NSUInteger rows = MAX((NSUInteger)1, MIN(maxRows, numLines));
+	sv.autohidesScrollers = (rows >= numLines); // persistent bar only if (improbably) clipped
+	CGFloat contentHeight = rows * lineHeight + 2 * inset.height;
+	CGFloat scrollHeight = contentHeight + borderChrome;
+	input.frame = NSMakeRect(0, 0, contentWidth, contentHeight);
+	sv.documentView = input;
+
+	// live character count under the field
+	NSTextField *countLabel = [NSTextField labelWithString:DYCharacterCountString(oldName.length)];
+	countLabel.font = [NSFont systemFontOfSize:NSFont.smallSystemFontSize];
+	countLabel.textColor = NSColor.secondaryLabelColor;
+	countLabel.alignment = NSTextAlignmentRight;
+	CGFloat labelHeight = ceil(countLabel.intrinsicContentSize.height);
+	CGFloat gap = 4;
+	countLabel.frame = NSMakeRect(0, 0, width, labelHeight);
+	sv.frame = NSMakeRect(0, labelHeight + gap, width, scrollHeight);
+
+	NSView *accessory = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, width, scrollHeight + gap + labelHeight)];
+	[accessory addSubview:sv];
+	[accessory addSubview:countLabel];
+	alert.accessoryView = accessory;
+
+	DYRenameFieldDelegate *fieldDelegate = [[DYRenameFieldDelegate alloc] init];
+	fieldDelegate.alert = alert;
+	fieldDelegate.countLabel = countLabel;
+	input.delegate = fieldDelegate;
+	// NSTextView.delegate is weak, so tie the delegate's lifetime to the alert
+	objc_setAssociatedObject(alert, _cmd, fieldDelegate, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+	// preselect the base name (without the extension), like the Finder
+	NSString *ext = oldName.pathExtension;
+	input.selectedRange = NSMakeRange(0, ext.length ? oldName.length - ext.length - 1 : oldName.length);
+	[alert addButtonWithTitle:NSLocalizedString(@"Rename", @"")];
+	[alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"")];
+	alert.window.initialFirstResponder = input;
+	if ([alert runModal] != NSAlertFirstButtonReturn)
+		return;
+
+	// file names are single-line; drop any newlines that slipped in (e.g. via paste)
+	NSString *newName = [[input.string componentsSeparatedByCharactersInSet:NSCharacterSet.newlineCharacterSet] componentsJoinedByString:@""];
+	if (newName.length == 0 || [newName isEqualToString:oldName])
+		return; // nothing to do
+	if ([newName containsString:@"/"] || [newName hasPrefix:@"."]) {
+		alert = [[NSAlert alloc] init];
+		alert.informativeText = NSLocalizedString(@"File names cannot contain “/” or begin with a period.", @"");
+		[alert runModal];
+		return;
+	}
+	NSString *newPath = [oldPath.stringByDeletingLastPathComponent stringByAppendingPathComponent:newName];
+	if ([NSFileManager.defaultManager fileExistsAtPath:newPath]) {
+		alert = [[NSAlert alloc] init];
+		alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"An item named “%@” already exists in this location.", @""), newName];
+		[alert runModal];
+		return;
+	}
+
+	NSUndoManager *um = slidesWindow.isMainWindow ? slidesWindow.undoManager : frontWindow.window.undoManager;
+	[self performRenameFrom:oldPath to:newPath undoManager:um];
+}
+
+// does the actual file rename, updates the UI, and registers the inverse for undo/redo
+- (void)performRenameFrom:(NSString *)oldPath to:(NSString *)newPath undoManager:(NSUndoManager *)um {
+	NSError * __autoreleasing err = nil;
+	if (![NSFileManager.defaultManager moveItemAtPath:oldPath toPath:newPath error:&err]) {
+		NSAlert *alert = [[NSAlert alloc] init];
+		alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"The file “%@” could not be renamed because of an error: %@", @""), oldPath.lastPathComponent, err.localizedDescription];
+		[alert runModal];
+		return;
+	}
+	[self fileWasRenamedFrom:oldPath to:newPath];
+	[um registerUndoWithTarget:self handler:^(id target) {
+		[target performRenameFrom:newPath to:oldPath undoManager:um];
+	}];
+	[um setActionName:NSLocalizedString(@"Rename", @"for undo")];
+}
+
+// propagate a completed rename to the open windows (a rename looks like a delete + re-add)
+- (void)fileWasRenamedFrom:(NSString *)oldPath to:(NSString *)newPath {
+	if (!IsAliasFilePath(oldPath))
+		[thumbsCache removeImageForKey:oldPath];
+	[creeveyWindows makeObjectsPerformSelector:@selector(fileWasDeleted:) withObject:oldPath];
+	[creeveyWindows makeObjectsPerformSelector:@selector(filesWereUndeleted:) withObject:@[newPath]];
+	if (slidesWindow.visible) {
+		if (slidesWindow.isMainWindow && [slidesWindow.currentFile isEqualToString:oldPath]) {
+			// keep the slideshow showing the renamed file: insert the new name, then drop the old one
+			[slidesWindow insertFile:newPath atIndex:slidesWindow.currentIndex];
+			[slidesWindow removeImageForFile:oldPath];
+		} else {
+			[slidesWindow removeImageForFile:oldPath];
+			[slidesWindow filesWereUndeleted:@[newPath]];
+		}
+	}
+}
+
 #pragma mark matrix view methods
 
 - (void)moveElsewhere {
@@ -936,6 +1187,8 @@ enum {
 	MOVE_TO_AGAIN,
 	COPY_TO,
 	COPY_TO_AGAIN,
+	RENAME,
+	DELETE_PERMANENTLY,
 	JPEG_OP = 100,
 	ROTATE_L = 107,
 	ROTATE_R = 105,
@@ -986,6 +1239,7 @@ enum {
 		case COPY_TO_AGAIN:
 		case COPY_TO:
 		case MOVE_TO_TRASH:
+		case DELETE_PERMANENTLY:
 		case JPEG_OP:
 			// only when slides isn't loading cache!
 			// only if writeable (we just test the first file in the list)
@@ -1022,6 +1276,13 @@ enum {
 			return slidesWindow.isMainWindow
 				? (slidesWindow.currentFile != nil)
 				: numSelected == 1;
+		case RENAME:
+			// renaming operates on a single file
+			return slidesWindow.isMainWindow
+				? (slidesWindow.currentFile &&
+					slidesWindow.currentImageLoaded &&
+					[NSFileManager.defaultManager isDeletableFileAtPath:slidesWindow.currentFile])
+				: numSelected == 1 && frontWindow && frontWindow.currentFilesDeletable;
 		case AUTO_ROTATE:
 			return YES;
 		case GET_INFO:

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -42,42 +42,46 @@ static BOOL FilesContainJPEG(NSArray *paths) {
 #define TAB(x,y)	[[NSTextTab alloc] initWithType:x location:y]
 NSMutableAttributedString* Fileinfo2EXIFString(NSString *origPath, DYImageCache *cache, BOOL moreExif) {
 	NSString *path = ResolveAliasToPath(origPath);
-	NSMutableString *s = [[NSMutableString alloc] init];
-	[s appendString:origPath.lastPathComponent];
+	// header = file name (+ alias) + size + dimensions; these are plain lines
+	NSMutableString *header = [origPath.lastPathComponent mutableCopy];
 	if (path != origPath)
-		[s appendFormat:@"\n[%@->%@]", NSLocalizedString(@"Alias", @""), path];
+		[header appendFormat:@"\n[%@->%@]", NSLocalizedString(@"Alias", @""), path];
 	DYImageInfo *i = [cache infoForKey:path];
+	NSString *exifStr = nil;
 	if (i) {
-		id exifStr = [DYExiftags tagsForFile:path moreTags:moreExif];
-		[s appendFormat:@"\n%@ (%qu bytes)\n%@: %d %@: %d",
+		exifStr = [DYExiftags tagsForFile:path moreTags:moreExif];
+		[header appendFormat:@"\n%@ (%qu bytes)\n%@: %d %@: %d",
 			FileSize2String(i->fileSize), i->fileSize,
 			NSLocalizedString(@"Width", @""), (int)i->pixelSize.width,
 			NSLocalizedString(@"Height", @""), (int)i->pixelSize.height];
-		if (exifStr) {
-			[s appendString:@"\n"];
-			[s appendString:exifStr];
-		}
 	} else {
 		unsigned long long fsize;
 		fsize = [[NSFileManager.defaultManager attributesOfItemAtPath:path.stringByResolvingSymlinksInPath error:NULL] fileSize];
 		// fsize will be 0 on error
-		[s appendFormat:@"\n%@ (%qu bytes)",
-			FileSize2String(fsize), fsize];
+		[header appendFormat:@"\n%@ (%qu bytes)", FileSize2String(fsize), fsize];
 	}
-	
-	static NSDictionary *atts;
-	if (atts == nil) {
+
+	static NSDictionary *headerAtts, *exifAtts;
+	if (headerAtts == nil) {
+		NSFont *font = [NSFont userFontOfSize:12];
+		// header: plain and left-aligned, so a long file name that wraps stays at
+		// the margin instead of indenting under the EXIF value column
+		headerAtts = @{
+			NSFontAttributeName: font,
+			NSParagraphStyleAttributeName: [[NSMutableParagraphStyle alloc] init],
+		};
+		// EXIF tags: two columns (label tab value); wrapped values align at the value column
 		float x = 160;
 		NSMutableParagraphStyle *styl = [[NSMutableParagraphStyle alloc] init];
 		styl.headIndent = x;
 		styl.tabStops = @[TAB(NSRightTabStopType,x-5), TAB(NSLeftTabStopType,x)];
 		styl.defaultTabInterval = 5;
-		atts = @{
-			NSFontAttributeName: [NSFont userFontOfSize:12],
-			NSParagraphStyleAttributeName: styl,
-		};
+		exifAtts = @{ NSFontAttributeName: font, NSParagraphStyleAttributeName: styl };
 	}
-	return [[NSMutableAttributedString alloc] initWithString:s attributes:atts];
+	NSMutableAttributedString *out = [[NSMutableAttributedString alloc] initWithString:header attributes:headerAtts];
+	if (exifStr)
+		[out appendAttributedString:[[NSAttributedString alloc] initWithString:[@"\n" stringByAppendingString:exifStr] attributes:exifAtts]];
+	return out;
 }
 
 @interface TimeIntervalPlusWeekToStringTransformer : NSValueTransformer

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -7,6 +7,7 @@
 
 @import UniformTypeIdentifiers;
 #import "CreeveyController.h"
+#import "KeyBindings.h"
 #import <objc/runtime.h>
 #import "DYJpegtran.h"
 #import "DYCarbonGoodies.h"
@@ -153,6 +154,7 @@ static NSString *DYCharacterCountString(NSUInteger n) {
 	NSMutableArray *_coalescedFilesToOpen;
 }
 @synthesize slidesWindow, jpegProgressBar, exifTextView, exifThumbnailDiscloseBtn, prefsWin, slideshowApplyBtn;
+@synthesize keyBindings = _keyBindings;
 
 +(void)initialize
 {
@@ -1039,9 +1041,18 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
 	NSUserDefaults *u = NSUserDefaults.standardUserDefaults;
+
+	// load the keybinding config and apply it to the menu (also creates a template
+	// on first launch so the file is there to edit)
+	_keyBindings = [[KeyBindings alloc] init];
+	[_keyBindings writeTemplateIfMissing]; // migrate/create before reading
+	[_keyBindings load];
+	[_keyBindings applyToMainMenu];
+	[_keyBindings reportErrorsIfAny];
+
 	[self showExifThumbnail:[u boolForKey:@"exifThumbnailShow"]
 			   shrinkWindow:NO];
-	
+
 	_appDidFinishLaunching = YES;
 	if (_windowsWereRestoredAtLaunch && _filesWereOpenedAtLaunch) {
 		// ugly hack to force the slideshow window to be on top of the restored windows
@@ -1371,6 +1382,22 @@ enum {
 
 - (IBAction)openAboutPanel:(id)sender {
 	[NSApp orderFrontStandardAboutPanelWithOptions:@{@"ApplicationIcon": [NSImage imageNamed:@"logo"]}];
+}
+
+#pragma mark configuration
+
+- (IBAction)reloadConfiguration:(id)sender {
+	[_keyBindings load];
+	[_keyBindings applyToMainMenu];
+	[_keyBindings reportErrorsIfAny];
+}
+
+- (IBAction)editConfiguration:(id)sender {
+	[_keyBindings openInEditor];
+}
+
+- (IBAction)revealConfiguration:(id)sender {
+	[_keyBindings revealInFinder];
 }
 
 // avoid warning "PerformSelector may cause a leak because its selector is unknown"

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -426,6 +426,7 @@ static NSModalResponse DYRunAlert(NSAlert *alert) {
 		@"MainWindowSplitViewTopHeight":@151.0f,
 		@"interfaceTextSize":@0, // 0 small (current), 1 medium, 2 large, 3 custom
 		@"interfaceTextCustomSize":@13, // point size when interfaceTextSize == 3 (custom)
+		@"copyPathnameShellQuoted":@YES, // Copy as Pathname: YES = shell-quoted, NO = Finder-style raw
 	}];
 
 	[NSValueTransformer setValueTransformer:[[TimeIntervalPlusWeekToStringTransformer alloc] init]
@@ -647,6 +648,25 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 	}
 }
 
+
+- (IBAction)copySelectedFilePaths:(id)sender {
+	NSArray<NSString *> *paths = frontWindow.currentSelection;
+	if (!paths.count) { NSBeep(); return; }
+	NSString *text;
+	if ([NSUserDefaults.standardUserDefaults boolForKey:@"copyPathnameShellQuoted"]) {
+		// shell-quoted: single-quote each path (escaping embedded quotes), space-separated
+		NSMutableArray *quoted = [NSMutableArray arrayWithCapacity:paths.count];
+		for (NSString *p in paths)
+			[quoted addObject:[NSString stringWithFormat:@"'%@'", [p stringByReplacingOccurrencesOfString:@"'" withString:@"'\\''"]]];
+		text = [quoted componentsJoinedByString:@" "];
+	} else {
+		// Finder-style: the raw POSIX path(s), one per line
+		text = [paths componentsJoinedByString:@"\n"];
+	}
+	NSPasteboard *pb = NSPasteboard.generalPasteboard;
+	[pb clearContents];
+	[pb setString:text forType:NSPasteboardTypeString];
+}
 
 - (IBAction)setDesktopPicture:(id)sender {
 	NSString *s = slidesWindow.isMainWindow
@@ -1503,6 +1523,7 @@ enum {
 	SHOW_DIRECTORY_BROWSER = 25,
 	SHOW_PATH_BAR = 26,
 	SHOW_UNSUPPORTED = 27,
+	COPY_PATHNAME = 28,
 	JPEG_OP = 100,
 	ROTATE_L = 107,
 	ROTATE_R = 105,
@@ -1596,6 +1617,8 @@ enum {
 			return numSelected > 0 && frontWindow && frontWindow.window.isMainWindow && frontWindow.filenamesDone;
 		case GO_TO_FOLDER:
 			return !slidesWindow.isMainWindow && frontWindow != nil;
+		case COPY_PATHNAME:
+			return !slidesWindow.isMainWindow && numSelected > 0;
 		case SHOW_PATH_BAR:
 			// Show/Hide verb-swap (Finder convention for toggling a UI element), no checkmark
 			menuItem.title = frontWindow.pathBarVisible ? @"Hide Path Bar" : @"Show Path Bar";

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -911,6 +911,10 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 
 	[NSApp endModalSession:session];
 	[jpegProgressBar.window orderOut:self];
+	// the slideshow refreshes via uncacheImage above; do the same for Quick Look, whose
+	// out-of-process render otherwise keeps showing the pre-transform image
+	if (QLPreviewPanel.sharedPreviewPanelExists && QLPreviewPanel.sharedPreviewPanel.isVisible)
+		[QLPreviewPanel.sharedPreviewPanel refreshCurrentPreviewItem];
 }
 
 - (IBAction)stopModal:(id)sender {

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -386,6 +386,7 @@ static NSModalResponse DYRunAlert(NSAlert *alert) {
 		@"slideshowWindowFitToImage": @NO,
 		@"exifThumbnailShow": @NO,
 		@"showFilenames": @YES,
+		@"showPathBar": @NO,
 		@"sortBy": @1, // sort by filename, ascending
 		@"Slideshow:RerandomizeOnLoop": @YES,
 		@"SlideshowSuppressLoopIndicator": @NO,
@@ -1446,6 +1447,8 @@ enum {
 	DELETE_PERMANENTLY,
 	QUICK_LOOK = 20, // 18=New Window, 19=Select None (tags live only in MainMenu.xib)
 	GO_TO_FOLDER = 24, // 21=Preferences, 22=End Slideshow, 23=Cheat Sheet (tags in MainMenu.xib)
+	SHOW_DIRECTORY_BROWSER = 25,
+	SHOW_PATH_BAR = 26,
 	JPEG_OP = 100,
 	ROTATE_L = 107,
 	ROTATE_R = 105,
@@ -1539,6 +1542,19 @@ enum {
 			return numSelected > 0 && frontWindow && frontWindow.window.isMainWindow && frontWindow.filenamesDone;
 		case GO_TO_FOLDER:
 			return !slidesWindow.isMainWindow && frontWindow != nil;
+		case SHOW_PATH_BAR:
+			// Show/Hide verb-swap (Finder convention for toggling a UI element), no checkmark
+			menuItem.title = frontWindow.pathBarVisible ? @"Hide Path Bar" : @"Show Path Bar";
+			menuItem.state = NSControlStateValueOff;
+			return !slidesWindow.isMainWindow && frontWindow != nil;
+		case SHOW_DIRECTORY_BROWSER:
+			menuItem.title = frontWindow.directoryBrowserVisible ? @"Hide Directory Browser" : @"Show Directory Browser";
+			menuItem.state = NSControlStateValueOff;
+			return !slidesWindow.isMainWindow && frontWindow != nil;
+		case SHOW_FILE_NAMES:
+			menuItem.title = frontWindow.imageMatrix.showFilenames ? @"Hide File Names" : @"Show File Names";
+			menuItem.state = NSControlStateValueOff;
+			return !slidesWindow.isMainWindow && frontWindow != nil;
 		case SET_DESKTOP:
 			return slidesWindow.isMainWindow
 				? (slidesWindow.currentFile != nil)
@@ -1554,7 +1570,6 @@ enum {
 			return YES;
 		case GET_INFO:
 		case SORT_NAME:
-		case SHOW_FILE_NAMES:
 			return !slidesWindow.isMainWindow;
 		default:
 			return YES;
@@ -1591,12 +1606,22 @@ enum {
 }
 
 - (IBAction)doShowFilenames:(id)sender {
+	// title flips Show/Hide in validateMenuItem, so no checkmark to set here
 	BOOL b = !frontWindow.imageMatrix.showFilenames;
-	NSMenuItem *item = sender;
-	item.state = b;
 	frontWindow.imageMatrix.showFilenames = b;
 	if (creeveyWindows.count == 1) // save as default if this is the only window
 		[NSUserDefaults.standardUserDefaults setBool:b forKey:@"showFilenames"];
+}
+
+- (IBAction)togglePathBar:(id)sender {
+	frontWindow.pathBarVisible = !frontWindow.pathBarVisible;
+	[NSUserDefaults.standardUserDefaults setBool:frontWindow.pathBarVisible forKey:@"showPathBar"];
+}
+
+- (IBAction)toggleDirectoryBrowser:(id)sender {
+	// the split view persists its own position (MainWindowSplitViewTopHeight), so the
+	// collapsed state is remembered across launches without a separate preference
+	frontWindow.directoryBrowserVisible = !frontWindow.directoryBrowserVisible;
 }
 
 - (IBAction)doAutoRotateDisplayedImage:(id)sender {
@@ -1884,7 +1909,7 @@ static void SendAction(NSMenuItem *sender) {
 	// make sure menu items are checked properly (code copied from windowChanged:)
 	NSMenu *m = [NSApp.mainMenu itemWithTag:VIEW_MENU].submenu;
 	[self updateMenuItemsForSorting:sortOrder];
-	[m itemWithTag:SHOW_FILE_NAMES].state = wc.imageMatrix.showFilenames ? NSControlStateValueOn : NSControlStateValueOff;
+	// Show File Names uses a Show/Hide title (set in validateMenuItem), so no checkmark here
 	[m itemWithTag:AUTO_ROTATE].state = wc.imageMatrix.autoRotate ? NSControlStateValueOn : NSControlStateValueOff;
 }
 
@@ -1920,7 +1945,7 @@ static void SendAction(NSMenuItem *sender) {
 	short int sortOrder = frontWindow.sortOrder;
 	NSMenu *m = [NSApp.mainMenu itemWithTag:VIEW_MENU].submenu;
 	[self updateMenuItemsForSorting:sortOrder];
-	[m itemWithTag:SHOW_FILE_NAMES].state = frontWindow.imageMatrix.showFilenames ? NSControlStateValueOn : NSControlStateValueOff;
+	// Show File Names uses a Show/Hide title (set in validateMenuItem), so no checkmark here
 	[m itemWithTag:AUTO_ROTATE].state = frontWindow.imageMatrix.autoRotate ? NSControlStateValueOn : NSControlStateValueOff;
 }
 

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -103,6 +103,15 @@ NSMutableAttributedString* Fileinfo2EXIFString(NSString *origPath, DYImageCache 
 }
 @end
 
+// YES only when the interface text size is "Custom" (index 3); used to enable the
+// custom point-size field/stepper in Preferences
+@interface DYTextSizeIsCustomTransformer : NSValueTransformer
+@end
+@implementation DYTextSizeIsCustomTransformer
++ (Class)transformedValueClass { return [NSNumber class]; }
+- (id)transformedValue:(id)v { return @([v integerValue] == 3); }
+@end
+
 static NSString *DYCharacterCountString(NSUInteger n) {
 	return [NSString stringWithFormat:(n == 1 ? NSLocalizedString(@"%lu character", @"")
 											  : NSLocalizedString(@"%lu characters", @"")), (unsigned long)n];
@@ -128,9 +137,14 @@ static NSString *DYCharacterCountString(NSUInteger n) {
 @end
 
 CGFloat DYInterfaceTextScale(void) {
-	switch ([NSUserDefaults.standardUserDefaults integerForKey:@"interfaceTextSize"]) {
+	NSUserDefaults *u = NSUserDefaults.standardUserDefaults;
+	switch ([u integerForKey:@"interfaceTextSize"]) {
 		case 1:  return 1.2;
 		case 2:  return 1.4;
+		case 3: { // custom: a point size relative to the system font (13pt ≈ Small/1.0×)
+			CGFloat pt = MAX(10, MIN(25, [u floatForKey:@"interfaceTextCustomSize"]));
+			return pt / NSFont.systemFontSize;
+		}
 		default: return 1.0;
 	}
 }
@@ -217,11 +231,14 @@ static NSModalResponse DYRunAlert(NSAlert *alert) {
 		@"startupSlideshowSuppressNewWindows":@NO,
 		@"slideshowDefaultMode":@0,
 		@"MainWindowSplitViewTopHeight":@151.0f,
-		@"interfaceTextSize":@0, // 0 small (current), 1 medium, 2 large
+		@"interfaceTextSize":@0, // 0 small (current), 1 medium, 2 large, 3 custom
+		@"interfaceTextCustomSize":@13, // point size when interfaceTextSize == 3 (custom)
 	}];
 
 	[NSValueTransformer setValueTransformer:[[TimeIntervalPlusWeekToStringTransformer alloc] init]
 									forName:@"TimeIntervalPlusWeekToStringTransformer"];
+	[NSValueTransformer setValueTransformer:[[DYTextSizeIsCustomTransformer alloc] init]
+									forName:@"DYTextSizeIsCustomTransformer"];
 }
 
 - (instancetype)init {
@@ -292,6 +309,7 @@ static NSModalResponse DYRunAlert(NSAlert *alert) {
 	[ud addObserver:self forKeyPath:@"values.DYWrappingMatrixMaxCellWidth" options:0 context:NULL];
 	[ud addObserver:self forKeyPath:@"values.appearance" options:0 context:NULL];
 	[ud addObserver:self forKeyPath:@"values.interfaceTextSize" options:0 context:NULL];
+	[ud addObserver:self forKeyPath:@"values.interfaceTextCustomSize" options:0 context:NULL];
 	localeChangeObserver = [NSNotificationCenter.defaultCenter addObserverForName:NSCurrentLocaleDidChangeNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:^(NSNotification *note) {
 		[u setDouble:[u doubleForKey:@"lastVersCheckTime"] forKey:@"lastVersCheckTime"];
 	}];
@@ -305,6 +323,7 @@ static NSModalResponse DYRunAlert(NSAlert *alert) {
 	[u removeObserver:self forKeyPath:@"values.DYWrappingMatrixMaxCellWidth"];
 	[u removeObserver:self forKeyPath:@"values.appearance"];
 	[u removeObserver:self forKeyPath:@"values.interfaceTextSize"];
+	[u removeObserver:self forKeyPath:@"values.interfaceTextCustomSize"];
 	[NSNotificationCenter.defaultCenter removeObserver:localeChangeObserver];
 	short int i;
 	for (i=0; i<NUM_FNKEY_CATS; ++i)
@@ -1554,7 +1573,8 @@ static void SendAction(NSMenuItem *sender) {
 		[self updateSlideshowFitToImage];
 	} else if ([keyPath isEqualToString:@"values.appearance"]) {
 		[self updateAppearance];
-	} else if ([keyPath isEqualToString:@"values.interfaceTextSize"]) {
+	} else if ([keyPath isEqualToString:@"values.interfaceTextSize"]
+			   || [keyPath isEqualToString:@"values.interfaceTextCustomSize"]) {
 		for (CreeveyMainWindowController *wc in creeveyWindows)
 			[wc reloadInterfaceTextSize];
 		[slidesWindow reloadInterfaceTextSize];

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -494,6 +494,7 @@ static NSModalResponse DYRunAlert(NSAlert *alert) {
 }
 
 - (void)applicationWillFinishLaunching:(NSNotification *)notification {
+	[CreeveyMainWindowController sweepLeftoverArchiveTemps]; // clear any extracted-archive leftovers from a prior run
 	[(NSPanel *)exifTextView.window setBecomesKeyOnlyIfNeeded:YES];
 	//[[exifTextView window] setHidesOnDeactivate:NO];
 	// this causes problems b/c the window can be foregrounded without the app
@@ -565,20 +566,26 @@ static NSModalResponse DYRunAlert(NSAlert *alert) {
 			files = frontWindow.currentSelection;
 		}
 	}
-	if (frontWindow.showUnsupportedFiles) {
-		// the slideshow can't display unsupported files, so drop them from the list; if the
-		// file the user started on is one of them, open it in its default app and bail
+	{
+		// the slideshow can't display archives (or, when shown, other unsupported files), so drop
+		// them from the list; if the file the user started on is one of them, open/enter it and bail
 		NSString *startFile = (startIdx != NSNotFound && startIdx < files.count) ? files[startIdx] : nil;
 		if (startFile && ![self shouldShowFile:[NSURL fileURLWithPath:startFile]]) {
-			[NSWorkspace.sharedWorkspace openURL:[NSURL fileURLWithPath:startFile]];
+			if ([frontWindow isArchivePath:startFile])
+				[frontWindow openArchive:startFile];
+			else
+				[NSWorkspace.sharedWorkspace openURL:[NSURL fileURLWithPath:startFile]];
 			return;
 		}
-		NSMutableArray *supported = [NSMutableArray arrayWithCapacity:files.count];
+		NSUInteger n = files.count;
+		NSMutableArray *supported = [NSMutableArray arrayWithCapacity:n];
 		for (NSString *p in files)
 			if ([self shouldShowFile:[NSURL fileURLWithPath:p]]) [supported addObject:p];
-		if (!supported.count) return;
-		files = supported;
-		startIdx = startFile ? [files indexOfObject:startFile] : NSNotFound;
+		if (supported.count != n) { // something (an archive or unsupported file) was dropped
+			if (!supported.count) return;
+			files = supported;
+			startIdx = startFile ? [files indexOfObject:startFile] : startIdx;
+		}
 	}
 	if (wantsUpdates) {
 		[slidesWindow setFilenames:files basePath:frontWindow.path wantsSubfolders:frontWindow.wantsSubfolders comparator:frontWindow.comparator sortOrder:frontWindow.sortOrder];
@@ -611,6 +618,10 @@ static NSModalResponse DYRunAlert(NSAlert *alert) {
 	// default app instead of the slideshow; a mixed selection still starts a slideshow of
 	// the supported files (unsupported ones are filtered out in startSlideshowFullscreen:)
 	NSArray *sel = frontWindow.currentSelection;
+	if (sel.count == 1 && [frontWindow isArchivePath:sel[0]]) { // open a .zip as a browsable folder
+		[frontWindow openArchive:sel[0]];
+		return;
+	}
 	if (sel.count) {
 		NSMutableArray *unsupported = [NSMutableArray array];
 		for (NSString *p in sel)
@@ -1572,6 +1583,7 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 	[u setBool:(slidesWindow.isMainWindow || creeveyWindows.count == 0) ? exifWasVisible : exifTextView.window.visible
 		forKey:@"getInfoVisible"];
 	[u synchronize];
+	[CreeveyMainWindowController sweepLeftoverArchiveTemps]; // remove any extracted-archive temp dirs on quit
 }
 
 - (void)openFilesCoalesced {
@@ -2270,8 +2282,14 @@ NSDirectoryEnumerator *CreeveyEnumerator(NSString *path, BOOL recurseSubfolders)
 	return [filetypes containsObject:pathExtension] || ([fileostypes containsObject:NSHFSTypeOfFile(path)] && ![disabledFiletypes containsObject:pathExtension]);
 }
 
+- (BOOL)isArchiveURL:(NSURL *)url {
+	NSString *ext = url.pathExtension.lowercaseString;
+	return [ext isEqualToString:@"zip"] || [ext isEqualToString:@"cbz"];
+}
+
 - (BOOL)shouldShowFile:(NSURL *)url includingUnsupported:(BOOL)includeUnsupported {
 	if ([self shouldShowFile:url]) return YES;
+	if ([self isArchiveURL:url]) return YES; // archives are always browsable (double-click to enter)
 	if (!includeUnsupported) return NO;
 	// admit any other non-hidden file (directories are already handled by the caller); these
 	// can't be shown in-app but can be Quick Looked / opened in their default app

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -944,8 +944,12 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 	[alert addButtonWithTitle:NSLocalizedString(@"Rename", @"")];
 	[alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"")];
 	alert.window.initialFirstResponder = input;
-	if ([alert runModal] != NSAlertFirstButtonReturn)
+	if ([alert runModal] != NSAlertFirstButtonReturn) {
+		// cancelled: keep the same image selected in the browser
+		if (!slidesWindow.isMainWindow)
+			[frontWindow.window makeFirstResponder:frontWindow.imageMatrix];
 		return;
+	}
 
 	// file names are single-line; drop any newlines that slipped in (e.g. via paste)
 	NSString *newName = [[input.string componentsSeparatedByCharactersInSet:NSCharacterSet.newlineCharacterSet] componentsJoinedByString:@""];
@@ -967,6 +971,19 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 
 	NSUndoManager *um = slidesWindow.isMainWindow ? slidesWindow.undoManager : frontWindow.window.undoManager;
 	[self performRenameFrom:oldPath to:newPath undoManager:um];
+
+	// keep the just-renamed file selected in the browser. It is re-added asynchronously
+	// (via filesWereUndeleted:), so defer the selection to run right after that.
+	if (!slidesWindow.isMainWindow) {
+		CreeveyMainWindowController *wc = frontWindow;
+		dispatch_async(dispatch_get_main_queue(), ^{
+			NSUInteger idx = [wc indexOfFilename:newPath];
+			if (idx != NSNotFound) {
+				[wc.window makeFirstResponder:wc.imageMatrix];
+				[wc selectIndex:idx];
+			}
+		});
+	}
 }
 
 // does the actual file rename, updates the UI, and registers the inverse for undo/redo

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -6,6 +6,7 @@
 //California 94305, USA.
 
 @import UniformTypeIdentifiers;
+@import Quartz; // QLPreviewPanel
 #import "CreeveyController.h"
 #import "KeyBindings.h"
 #import <objc/runtime.h>
@@ -356,6 +357,14 @@ CGFloat DYInterfaceTextScale(void) {
 	BOOL fullscreen = [NSUserDefaults.standardUserDefaults integerForKey:@"slideshowDefaultMode"] == 0;
 	if (NSApp.currentEvent.modifierFlags & NSEventModifierFlagOption) fullscreen = !fullscreen;
 	[self startSlideshowFullscreen:fullscreen];
+}
+
+- (IBAction)quickLook:(id)sender {
+	QLPreviewPanel *panel = QLPreviewPanel.sharedPreviewPanel;
+	if (QLPreviewPanel.sharedPreviewPanelExists && panel.isVisible)
+		[panel orderOut:nil];
+	else
+		[panel makeKeyAndOrderFront:nil];
 }
 
 static void ShowDirectoryContentsIfPossible(NSURL *u) {
@@ -1228,6 +1237,7 @@ enum {
 	COPY_TO_AGAIN,
 	RENAME,
 	DELETE_PERMANENTLY,
+	QUICK_LOOK = 20, // 18=New Window, 19=Select None (tags live only in MainMenu.xib)
 	JPEG_OP = 100,
 	ROTATE_L = 107,
 	ROTATE_R = 105,
@@ -1311,6 +1321,11 @@ enum {
 		case BEGIN_SLIDESHOW_ALTERNATE:
 			if (slidesWindow.isMainWindow ) return NO;
 			return frontWindow && frontWindow.filenamesDone && frontWindow.displayedFilenames.count;
+		case QUICK_LOOK:
+			// SPACE only previews when a browser window with a selection is frontmost,
+			// so it won't hijack SPACE in the slideshow, Prefs, or text fields
+			if (slidesWindow.isMainWindow) return NO;
+			return numSelected > 0 && frontWindow && frontWindow.window.isMainWindow && frontWindow.filenamesDone;
 		case SET_DESKTOP:
 			return slidesWindow.isMainWindow
 				? (slidesWindow.currentFile != nil)

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -2062,10 +2062,12 @@ static void SendAction(NSMenuItem *sender) {
 	if (creeveyWindows.count && exifWasVisible)
 		[exifTextView.window orderFront:nil];
 	if (creeveyWindows.count && frontWindow.currentSelection.count <= 1) {
-		NSArray *a = frontWindow.displayedFilenames;
-		NSUInteger i = slidesWindow.currentIndex;
-		if (i < a.count
-			&& [a[i] isEqualToString:slidesWindow.currentFile])
+		// select the last-shown file by name, not index: after deletions/renames (or random/
+		// subset), the slideshow's list and the browser's displayedFilenames diverge, so the
+		// old index cross-check failed and left the pre-slideshow (start) file selected
+		NSString *endFile = slidesWindow.currentFile;
+		NSUInteger i = endFile ? [frontWindow indexOfFilename:endFile] : NSNotFound;
+		if (i != NSNotFound)
 			[frontWindow selectIndex:i];
 	}
 }

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -122,6 +122,14 @@ static NSString *DYCharacterCountString(NSUInteger n) {
 }
 @end
 
+CGFloat DYInterfaceTextScale(void) {
+	switch ([NSUserDefaults.standardUserDefaults integerForKey:@"interfaceTextSize"]) {
+		case 1:  return 1.25;
+		case 2:  return 1.5;
+		default: return 1.0;
+	}
+}
+
 @interface CreeveyController () <NSMenuItemValidation>
 @property (nonatomic) BOOL appDidFinishLaunching;
 @property (nonatomic) BOOL filesWereOpenedAtLaunch;
@@ -197,6 +205,7 @@ static NSString *DYCharacterCountString(NSUInteger n) {
 		@"startupSlideshowSuppressNewWindows":@NO,
 		@"slideshowDefaultMode":@0,
 		@"MainWindowSplitViewTopHeight":@151.0f,
+		@"interfaceTextSize":@0, // 0 small (current), 1 medium, 2 large
 	}];
 
 	[NSValueTransformer setValueTransformer:[[TimeIntervalPlusWeekToStringTransformer alloc] init]
@@ -270,6 +279,7 @@ static NSString *DYCharacterCountString(NSUInteger n) {
 	[ud addObserver:self forKeyPath:@"values.slideshowWindowFitToImage" options:0 context:NULL];
 	[ud addObserver:self forKeyPath:@"values.DYWrappingMatrixMaxCellWidth" options:0 context:NULL];
 	[ud addObserver:self forKeyPath:@"values.appearance" options:0 context:NULL];
+	[ud addObserver:self forKeyPath:@"values.interfaceTextSize" options:0 context:NULL];
 	localeChangeObserver = [NSNotificationCenter.defaultCenter addObserverForName:NSCurrentLocaleDidChangeNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:^(NSNotification *note) {
 		[u setDouble:[u doubleForKey:@"lastVersCheckTime"] forKey:@"lastVersCheckTime"];
 	}];
@@ -282,6 +292,7 @@ static NSString *DYCharacterCountString(NSUInteger n) {
 	[u removeObserver:self forKeyPath:@"values.slideshowWindowFitToImage"];
 	[u removeObserver:self forKeyPath:@"values.DYWrappingMatrixMaxCellWidth"];
 	[u removeObserver:self forKeyPath:@"values.appearance"];
+	[u removeObserver:self forKeyPath:@"values.interfaceTextSize"];
 	[NSNotificationCenter.defaultCenter removeObserver:localeChangeObserver];
 	short int i;
 	for (i=0; i<NUM_FNKEY_CATS; ++i)
@@ -1498,6 +1509,10 @@ static void SendAction(NSMenuItem *sender) {
 		[self updateSlideshowFitToImage];
 	} else if ([keyPath isEqualToString:@"values.appearance"]) {
 		[self updateAppearance];
+	} else if ([keyPath isEqualToString:@"values.interfaceTextSize"]) {
+		for (CreeveyMainWindowController *wc in creeveyWindows)
+			[wc reloadInterfaceTextSize];
+		[slidesWindow reloadInterfaceTextSize];
 	}
 }
 

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -122,8 +122,15 @@ static NSString *DYCharacterCountString(NSUInteger n) {
 @interface DYRenameFieldDelegate : NSObject <NSTextViewDelegate>
 @property (weak) NSAlert *alert;
 @property (weak) NSTextField *countLabel;
+@property (strong) NSUndoManager *undoManager; // dedicated undo stack for the rename field
 @end
 @implementation DYRenameFieldDelegate
+// give the text view its own undo manager so Cmd-Z/Shift-Cmd-Z work inside the modal alert,
+// where the alert window doesn't vend one of its own
+- (NSUndoManager *)undoManagerForTextView:(NSTextView *)view {
+	if (!_undoManager) _undoManager = [[NSUndoManager alloc] init];
+	return _undoManager;
+}
 - (BOOL)textView:(NSTextView *)textView doCommandBySelector:(SEL)commandSelector {
 	if (commandSelector == @selector(insertNewline:)) {
 		[self.alert.buttons.firstObject performClick:nil];
@@ -1165,6 +1172,7 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 	NSTextView *input = [[NSTextView alloc] initWithFrame:NSMakeRect(0, 0, contentWidth, 54)];
 	input.font = font;
 	input.richText = NO;
+	input.allowsUndo = YES; // enable Cmd-Z / Shift-Cmd-Z for typed text
 	// never let macOS "helpfully" rewrite a file name
 	input.automaticQuoteSubstitutionEnabled = NO;
 	input.automaticDashSubstitutionEnabled = NO;

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -183,6 +183,11 @@ static NSString *DYCharacterCountString(NSUInteger n) {
 	BOOL _userPickedRow; // YES once the user arrows/clicks a row, so Enter honors it
 	NSUInteger _scanToken; // bumped per scan so a stale background result can be discarded
 	BOOL _scanning;        // YES while the current scan is still running
+	NSString *_typedPrefix; // the real user-typed text, without any inline-completion ghost tail
+	BOOL _suppressChange;   // YES while we programmatically edit the field (ghost insert/clear)
+	BOOL _deleting;         // set by delete keys so we don't re-suggest while erasing
+	BOOL _wantGhost;        // whether the next scan result should show an inline completion
+	BOOL _ghostShowing;     // YES while an inline completion tail is actually displayed
 }
 static NSMutableArray *_dyGoToFolderLive; // keep controllers alive while their sheet is up
 
@@ -210,6 +215,8 @@ static NSMutableArray *_dyGoToFolderLive; // keep controllers alive while their 
 	_field = [[NSTextField alloc] initWithFrame:NSMakeRect(20, 238, 520, 24)];
 	_field.delegate = self;
 	_field.stringValue = start ?: @"~/";
+	_typedPrefix = _field.stringValue; // no inline ghost until the user interacts
+	_wantGhost = NO;
 	[cv addSubview:_field];
 
 	NSScrollView *sv = [[NSScrollView alloc] initWithFrame:NSMakeRect(20, 52, 520, 178)];
@@ -315,8 +322,12 @@ static NSMutableArray *_dyGoToFolderLive; // keep controllers alive while their 
 			[self->_spinner stopAnimation:nil];
 			[self->_matches setArray:found];
 			[self->_table reloadData];
-			if (self->_matches.count)
+			if (self->_matches.count) {
 				[self->_table selectRowIndexes:[NSIndexSet indexSetWithIndex:0] byExtendingSelection:NO];
+				if (self->_wantGhost) [self showInlineCompletionForRow:0]; // Finder-style ghost of the top match
+			} else {
+				[self clearGhost]; // no matches: strip any leftover ghost
+			}
 		});
 	});
 }
@@ -328,17 +339,52 @@ static NSMutableArray *_dyGoToFolderLive; // keep controllers alive while their 
 	if (row < 0) row = 0; else if (row >= (NSInteger)_matches.count) row = _matches.count - 1;
 	[_table selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
 	[_table scrollRowToVisible:row];
+	[self showInlineCompletionForRow:row]; // ghost follows the highlighted row (Finder-style)
+}
+
+// Show the highlighted match's remaining characters as selected "ghost" text after what the user
+// typed; → / Tab accept it. Reverts to the typed text if the match no longer shares that prefix.
+- (void)showInlineCompletionForRow:(NSInteger)row {
+	NSString *typed = _typedPrefix ?: @"";
+	NSTextView *ed = (NSTextView *)_field.currentEditor;
+	if (!ed) return;
+	NSString *sugg = (row >= 0 && row < (NSInteger)_matches.count)
+		? ([typed hasPrefix:@"~"] ? _matches[row].stringByAbbreviatingWithTildeInPath : _matches[row])
+		: nil;
+	if (typed.length && sugg.length > typed.length &&
+		[[sugg substringToIndex:typed.length] caseInsensitiveCompare:typed] == NSOrderedSame) {
+		_suppressChange = YES;
+		ed.string = sugg;
+		ed.selectedRange = NSMakeRange(typed.length, sugg.length - typed.length); // select the ghost tail
+		_suppressChange = NO;
+		_ghostShowing = YES;
+	} else {
+		[self clearGhost];
+	}
+}
+
+- (void)clearGhost {
+	_ghostShowing = NO;
+	NSTextView *ed = (NSTextView *)_field.currentEditor;
+	NSString *typed = _typedPrefix ?: @"";
+	if (!ed || [ed.string isEqualToString:typed]) return;
+	_suppressChange = YES;
+	ed.string = typed;
+	ed.selectedRange = NSMakeRange(typed.length, 0);
+	_suppressChange = NO;
 }
 
 - (void)completeSelection {
 	if (_table.selectedRow < 0 || _table.selectedRow >= (NSInteger)_matches.count) return;
 	_field.stringValue = [_matches[_table.selectedRow].stringByAbbreviatingWithTildeInPath stringByAppendingString:@"/"];
 	_field.currentEditor.selectedRange = NSMakeRange(_field.stringValue.length, 0);
+	_typedPrefix = _field.stringValue; // the drilled path is now the user's text
 	_userPickedRow = NO; // drilled in: back to typed-path mode for the new folder
+	_wantGhost = YES;    // preview the first child of the new folder
 	[self updateMatches];
 }
 
-- (void)rowClicked:(id)sender { _userPickedRow = YES; }
+- (void)rowClicked:(id)sender { _userPickedRow = YES; [self showInlineCompletionForRow:_table.selectedRow]; }
 
 - (id)windowWillReturnFieldEditor:(NSWindow *)sender toObject:(id)client {
 	if (client != _field) return nil; // default editor for anything else
@@ -346,19 +392,37 @@ static NSMutableArray *_dyGoToFolderLive; // keep controllers alive while their 
 	return _fieldEditor;
 }
 
-- (void)controlTextDidChange:(NSNotification *)n { _userPickedRow = NO; [self updateMatches]; }
+- (void)controlTextDidChange:(NSNotification *)n {
+	if (_suppressChange) return; // our own ghost edit, not a user keystroke
+	_userPickedRow = NO;
+	_ghostShowing = NO;                 // the edit replaced any ghost; re-shown by the scan below
+	_typedPrefix = _field.stringValue; // any previous ghost was just replaced by the edit
+	_wantGhost = !_deleting;            // don't re-suggest while the user is erasing
+	_deleting = NO;
+	[self updateMatches];
+}
 
 - (BOOL)control:(NSControl *)control textView:(NSTextView *)tv doCommandBySelector:(SEL)sel {
-	if (sel == @selector(insertNewline:))    { [self accept:nil];        return YES; }
-	if (sel == @selector(cancelOperation:))  { [self cancel:nil];        return YES; }
-	if (sel == @selector(moveDown:))         { [self moveSelectionBy:1];  return YES; }
-	if (sel == @selector(moveUp:))           { [self moveSelectionBy:-1]; return YES; }
-	if (sel == @selector(insertTab:))        { [self completeSelection];  return YES; }
-	if (sel == @selector(moveRight:)) { // → completes the highlighted folder, but only
-		// at the end of the text so mid-text editing still moves the caret
-		if (NSMaxRange(tv.selectedRange) >= tv.string.length) { [self completeSelection]; return YES; }
+	// Finder-style: the path field always keeps focus. ↑/↓ move the highlighted suggestion (and
+	// its inline "ghost" completion), Return goes, Esc cancels. Tab completes the highlighted
+	// suggestion into the path (drilling one level, staying in edit mode); → does the same when the
+	// selection reaches the end of the text — mid-text → just moves the caret.
+	if (sel == @selector(deleteBackward:) || sel == @selector(deleteForward:)) { _deleting = YES; return NO; }
+	if (sel == @selector(insertNewline:))   { [self accept:nil];        return YES; }
+	if (sel == @selector(cancelOperation:)) { [self cancel:nil];        return YES; }
+	if (sel == @selector(moveDown:))        { [self moveSelectionBy:1];  return YES; }
+	if (sel == @selector(moveUp:))          { [self moveSelectionBy:-1]; return YES; }
+	if (sel == @selector(insertTab:))       { [self completeSelection];  return YES; }
+	if (sel == @selector(moveRight:)) {
+		// only accept when an inline ghost is actually showing; a fully-selected path with no
+		// suggestion (e.g. just after opening) should just deselect and move the caret to the end
+		if (_ghostShowing) { [self completeSelection]; return YES; }
 		return NO;
 	}
+	// any other command (←, Home, word-nav, …): drop a showing ghost first so no stray
+	// completion text is left behind, then let the editor act on the real typed text
+	if (tv.selectedRange.length && NSMaxRange(tv.selectedRange) >= tv.string.length && _typedPrefix.length)
+		[self clearGhost];
 	return NO;
 }
 

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -376,7 +376,10 @@ static NSModalResponse DYRunAlert(NSAlert *alert) {
 	NSMutableArray *creeveyWindows;
 	CreeveyMainWindowController * __weak frontWindow;
 	NSArray *_prefWinNibItems;
-	
+
+	NSMutableArray<NSDictionary *> *_recentFolders; // Open Recent: in-memory, most-recent-first
+	BOOL _recentFoldersDirty;                        // unsaved changes since last flush
+
 	DYImageCache *thumbsCache;
 	
 	id localeChangeObserver;
@@ -434,6 +437,8 @@ static NSModalResponse DYRunAlert(NSAlert *alert) {
 		@"interfaceTextSize":@0, // 0 small (current), 1 medium, 2 large, 3 custom
 		@"interfaceTextCustomSize":@13, // point size when interfaceTextSize == 3 (custom)
 		@"copyPathnameShellQuoted":@YES, // Copy as Pathname: YES = shell-quoted, NO = Finder-style raw
+		@"recentFolders":@[],            // Open Recent list (array of state dicts, most-recent-first)
+		@"recentFoldersMax":@10,         // how many recent folders to remember
 	}];
 
 	[NSValueTransformer setValueTransformer:[[TimeIntervalPlusWeekToStringTransformer alloc] init]
@@ -673,6 +678,112 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 	NSPasteboard *pb = NSPasteboard.generalPasteboard;
 	[pb clearContents];
 	[pb setString:text forType:NSPasteboardTypeString];
+}
+
+#pragma mark Open Recent
+- (NSMutableArray<NSDictionary *> *)recentFolders {
+	if (!_recentFolders) {
+		NSArray *saved = [NSUserDefaults.standardUserDefaults arrayForKey:@"recentFolders"];
+		_recentFolders = saved ? [saved mutableCopy] : [NSMutableArray array];
+	}
+	return _recentFolders;
+}
+
+// Upsert the window's current folder to the top of the list with its full state.
+- (void)noteRecentFolderForWindow:(CreeveyMainWindowController *)wc {
+	NSDictionary *state = wc.currentStateDictionary;
+	if (!state) return;
+	NSString *path = state[@"path"];
+	NSMutableArray *list = self.recentFolders;
+	NSUInteger existing = [list indexOfObjectPassingTest:^BOOL(NSDictionary *e, NSUInteger idx, BOOL *stop){
+		return [e[@"path"] isEqual:path];
+	}];
+	if (existing != NSNotFound) [list removeObjectAtIndex:existing];
+	[list insertObject:state atIndex:0];
+	NSInteger max = MAX(1, [NSUserDefaults.standardUserDefaults integerForKey:@"recentFoldersMax"]);
+	while ((NSInteger)list.count > max) [list removeLastObject];
+	_recentFoldersDirty = YES;
+}
+
+- (void)flushRecentFolders {
+	if (!_recentFoldersDirty) return;
+	[NSUserDefaults.standardUserDefaults setObject:_recentFolders forKey:@"recentFolders"];
+	_recentFoldersDirty = NO;
+}
+
+// NSMenuDelegate for the File > Open Recent submenu (delegate wired in MainMenu.xib).
+- (void)menuNeedsUpdate:(NSMenu *)menu {
+	if (frontWindow) [self noteRecentFolderForWindow:frontWindow]; // reflect the current folder's latest state
+	[self flushRecentFolders];
+	menu.autoenablesItems = NO; // we set each item's enabled state explicitly
+	[menu removeAllItems];
+	NSMutableArray *list = self.recentFolders;
+	NSFileManager *fm = NSFileManager.defaultManager;
+	BOOL hasInvalid = NO;
+	if (list.count == 0) {
+		NSMenuItem *none = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"No Recent Folders", @"") action:NULL keyEquivalent:@""];
+		none.enabled = NO;
+		[menu addItem:none];
+	} else {
+		for (NSDictionary *e in list) {
+			NSString *path = e[@"path"];
+			BOOL exists = [fm fileExistsAtPath:path];
+			if (!exists) hasInvalid = YES;
+			NSMenuItem *mi = [[NSMenuItem alloc] initWithTitle:(e[@"displayPath"] ?: path)
+														action:@selector(openRecentFolder:) keyEquivalent:@""];
+			mi.target = self;
+			mi.representedObject = e;
+			mi.enabled = exists; // missing folders greyed out
+			NSImage *icon = [NSWorkspace.sharedWorkspace iconForFile:path];
+			icon.size = NSMakeSize(16, 16);
+			mi.image = icon;
+			[menu addItem:mi];
+		}
+	}
+	[menu addItem:NSMenuItem.separatorItem];
+	NSMenuItem *removeInvalid = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"Remove Invalid", @"")
+														   action:@selector(removeInvalidRecent:) keyEquivalent:@""];
+	removeInvalid.target = self;
+	removeInvalid.enabled = hasInvalid;
+	[menu addItem:removeInvalid];
+	NSMenuItem *clear = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"Clear Menu", @"")
+												   action:@selector(clearRecentMenu:) keyEquivalent:@""];
+	clear.target = self;
+	clear.enabled = list.count > 0;
+	[menu addItem:clear];
+}
+
+- (IBAction)openRecentFolder:(NSMenuItem *)sender {
+	NSDictionary *e = sender.representedObject;
+	if (![e isKindOfClass:NSDictionary.class]) return;
+	if (![NSFileManager.defaultManager fileExistsAtPath:e[@"path"]]) { NSBeep(); return; }
+	CreeveyMainWindowController *wc = frontWindow;
+	if (!wc || !creeveyWindows.count) {
+		[self newWindow:nil]; // open a browser window if none exists (init:NO — restoreState sets the path)
+		wc = creeveyWindows.lastObject;
+	}
+	[wc showWindow:nil];
+	[wc.window makeKeyAndOrderFront:nil];
+	[wc restoreState:e];
+}
+
+- (IBAction)clearRecentMenu:(id)sender {
+	[self.recentFolders removeAllObjects];
+	_recentFoldersDirty = YES;
+	[self flushRecentFolders];
+}
+
+- (IBAction)removeInvalidRecent:(id)sender {
+	NSFileManager *fm = NSFileManager.defaultManager;
+	NSMutableArray *list = self.recentFolders;
+	NSIndexSet *invalid = [list indexesOfObjectsPassingTest:^BOOL(NSDictionary *e, NSUInteger idx, BOOL *stop){
+		return ![fm fileExistsAtPath:e[@"path"]];
+	}];
+	if (invalid.count) {
+		[list removeObjectsAtIndexes:invalid];
+		_recentFoldersDirty = YES;
+		[self flushRecentFolders];
+	}
 }
 
 - (IBAction)setDesktopPicture:(id)sender {
@@ -1450,6 +1561,8 @@ static void ShowDirectoryContentsIfPossible(NSURL *u) {
 	NSUserDefaults *u = NSUserDefaults.standardUserDefaults;
 	if (creeveyWindows.count)
 		[frontWindow updateDefaults];
+	if (frontWindow) [self noteRecentFolderForWindow:frontWindow]; // capture the current folder's final state
+	[self flushRecentFolders];
 	[u setBool:(slidesWindow.isMainWindow || creeveyWindows.count == 0) ? exifWasVisible : exifTextView.window.visible
 		forKey:@"getInfoVisible"];
 	[u synchronize];
@@ -1700,17 +1813,20 @@ enum {
 	frontWindow.imageMatrix.showFilenames = b;
 	if (creeveyWindows.count == 1) // save as default if this is the only window
 		[NSUserDefaults.standardUserDefaults setBool:b forKey:@"showFilenames"];
+	[self noteRecentFolderForWindow:frontWindow];
 }
 
 - (IBAction)togglePathBar:(id)sender {
 	frontWindow.pathBarVisible = !frontWindow.pathBarVisible;
 	[NSUserDefaults.standardUserDefaults setBool:frontWindow.pathBarVisible forKey:@"showPathBar"];
+	[self noteRecentFolderForWindow:frontWindow];
 }
 
 - (IBAction)toggleDirectoryBrowser:(id)sender {
 	// the split view persists its own position (MainWindowSplitViewTopHeight), so the
 	// collapsed state is remembered across launches without a separate preference
 	frontWindow.directoryBrowserVisible = !frontWindow.directoryBrowserVisible;
+	[self noteRecentFolderForWindow:frontWindow];
 }
 
 - (IBAction)toggleUnsupportedFiles:(id)sender {
@@ -1726,6 +1842,7 @@ enum {
 	slidesWindow.autoRotate = b;
 	if (creeveyWindows.count == 1 || slidesWindow.isMainWindow)
 		[NSUserDefaults.standardUserDefaults setBool:b forKey:@"autoRotateByOrientationTag"];
+	if (!slidesWindow.isMainWindow) [self noteRecentFolderForWindow:frontWindow];
 }
 
 #pragma mark prefs stuff
@@ -2026,6 +2143,8 @@ static void SendAction(NSMenuItem *sender) {
 - (void)windowClosed:(NSNotification *)n {
 	NSWindowController *wc = [n.object windowController];
 	if ([creeveyWindows indexOfObjectIdenticalTo:wc] != NSNotFound) {
+		[self noteRecentFolderForWindow:(CreeveyMainWindowController *)wc]; // capture the closing window's folder+state
+		[self flushRecentFolders];
 		if (wc.window == frontWindow.window) {
 			// for some reason closing a tab will call windowChanged: (with the new window) before windowClosed: (with the old window)
 			frontWindow = nil;

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -136,6 +136,174 @@ static NSString *DYCharacterCountString(NSUInteger n) {
 }
 @end
 
+#pragma mark Go to Folder sheet
+// A Finder-style "Go to the folder:" sheet: a path field with ~ expansion and a
+// list of matching sub-folders below. Enter goes to the typed path (or the
+// selected match); Tab / double-click completes; Esc cancels. Directories only.
+@interface DYGoToFolderController : NSObject <NSTextFieldDelegate, NSTableViewDataSource, NSTableViewDelegate>
+@end
+@implementation DYGoToFolderController {
+	NSWindow *_parent, *_sheet;
+	NSTextField *_field;
+	NSTableView *_table;
+	NSMutableArray<NSString *> *_matches;
+	void (^_completion)(NSString *);
+	BOOL _userPickedRow; // YES once the user arrows/clicks a row, so Enter honors it
+}
+static NSMutableArray *_dyGoToFolderLive; // keep controllers alive while their sheet is up
+
++ (void)presentForWindow:(NSWindow *)parent startingPath:(NSString *)start completion:(void(^)(NSString *))completion {
+	DYGoToFolderController *c = [[DYGoToFolderController alloc] init];
+	c->_parent = parent;
+	c->_completion = [completion copy];
+	c->_matches = [NSMutableArray array];
+	[c presentStartingAt:start];
+}
+
+- (void)presentStartingAt:(NSString *)start {
+	if (!_dyGoToFolderLive) _dyGoToFolderLive = [NSMutableArray array];
+	[_dyGoToFolderLive addObject:self];
+
+	_sheet = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 560, 300)
+										 styleMask:NSWindowStyleMaskTitled backing:NSBackingStoreBuffered defer:NO];
+	NSView *cv = _sheet.contentView;
+
+	NSTextField *label = [NSTextField labelWithString:NSLocalizedString(@"Go to the folder:", @"")];
+	label.frame = NSMakeRect(20, 268, 520, 17);
+	[cv addSubview:label];
+
+	_field = [[NSTextField alloc] initWithFrame:NSMakeRect(20, 238, 520, 24)];
+	_field.delegate = self;
+	_field.stringValue = start ?: @"~/";
+	[cv addSubview:_field];
+
+	NSScrollView *sv = [[NSScrollView alloc] initWithFrame:NSMakeRect(20, 52, 520, 178)];
+	sv.hasVerticalScroller = YES;
+	sv.borderType = NSBezelBorder;
+	_table = [[NSTableView alloc] initWithFrame:sv.bounds];
+	NSTableColumn *col = [[NSTableColumn alloc] initWithIdentifier:@"path"];
+	col.width = 500;
+	[_table addTableColumn:col];
+	_table.headerView = nil;
+	_table.dataSource = self;
+	_table.delegate = self;
+	_table.target = self;
+	_table.action = @selector(rowClicked:);
+	_table.doubleAction = @selector(accept:);
+	sv.documentView = _table;
+	[cv addSubview:sv];
+
+	NSButton *cancel = [NSButton buttonWithTitle:NSLocalizedString(@"Cancel", @"") target:self action:@selector(cancel:)];
+	cancel.frame = NSMakeRect(366, 12, 90, 32);
+	[cv addSubview:cancel];
+	NSButton *go = [NSButton buttonWithTitle:NSLocalizedString(@"Go", @"") target:self action:@selector(accept:)];
+	go.frame = NSMakeRect(458, 12, 84, 32);
+	[cv addSubview:go];
+
+	_sheet.initialFirstResponder = _field;
+	[self updateMatches];
+	[_parent beginSheet:_sheet completionHandler:^(NSModalResponse r){}];
+	_field.currentEditor.selectedRange = NSMakeRange(_field.stringValue.length, 0);
+}
+
+- (void)finishWithPath:(NSString *)path {
+	void (^completion)(NSString *) = _completion;
+	[_parent endSheet:_sheet];
+	[_dyGoToFolderLive removeObject:self];
+	if (completion) completion(path);
+}
+
+- (void)cancel:(id)sender { [self finishWithPath:nil]; }
+
+- (void)accept:(id)sender {
+	NSString *chosen = nil;
+	BOOL haveRow = _table.selectedRow >= 0 && _table.selectedRow < (NSInteger)_matches.count;
+	if (_userPickedRow && haveRow) {
+		chosen = _matches[_table.selectedRow]; // a folder you arrowed/clicked to wins
+	} else {
+		NSFileManager *fm = NSFileManager.defaultManager;
+		NSString *typed = _field.stringValue.stringByExpandingTildeInPath;
+		BOOL isDir;
+		if (typed.length && [fm fileExistsAtPath:typed isDirectory:&isDir] && isDir)
+			chosen = typed; // otherwise the typed path wins if it's a real directory
+		else if (haveRow)
+			chosen = _matches[_table.selectedRow];
+	}
+	if (chosen) [self finishWithPath:chosen];
+	else NSBeep();
+}
+
+- (void)updateMatches {
+	NSString *raw = _field.stringValue;
+	NSString *text = raw.stringByExpandingTildeInPath;
+	NSString *dir, *prefix;
+	// expanding ~ strips a trailing slash, so test the raw text for it: a trailing
+	// slash means "list everything in this folder" (empty prefix)
+	if (raw.length == 0)           { dir = NSHomeDirectory(); prefix = @""; }
+	else if ([raw hasSuffix:@"/"]) { dir = text; prefix = @""; }
+	else                           { dir = text.stringByDeletingLastPathComponent; prefix = text.lastPathComponent; }
+	_field.toolTip = text; // the field scrolls with the caret; show the full path on hover
+	[_matches removeAllObjects];
+	NSFileManager *fm = NSFileManager.defaultManager;
+	NSString *lp = prefix.lowercaseString;
+	BOOL showHidden = [prefix hasPrefix:@"."]; // reveal dot-folders once the user types a dot
+	for (NSString *name in [fm contentsOfDirectoryAtPath:dir error:NULL]) {
+		if (!showHidden && [name hasPrefix:@"."]) continue;
+		if (lp.length && ![name.lowercaseString hasPrefix:lp]) continue;
+		NSString *full = [dir stringByAppendingPathComponent:name];
+		BOOL isDir;
+		if ([fm fileExistsAtPath:full isDirectory:&isDir] && isDir)
+			[_matches addObject:full];
+	}
+	[_matches sortUsingComparator:^NSComparisonResult(NSString *a, NSString *b){
+		return [a.lastPathComponent localizedStandardCompare:b.lastPathComponent];
+	}];
+	[_table reloadData];
+	if (_matches.count)
+		[_table selectRowIndexes:[NSIndexSet indexSetWithIndex:0] byExtendingSelection:NO];
+}
+
+- (void)moveSelectionBy:(NSInteger)delta {
+	if (!_matches.count) return;
+	_userPickedRow = YES;
+	NSInteger row = _table.selectedRow + delta;
+	if (row < 0) row = 0; else if (row >= (NSInteger)_matches.count) row = _matches.count - 1;
+	[_table selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
+	[_table scrollRowToVisible:row];
+}
+
+- (void)completeSelection {
+	if (_table.selectedRow < 0 || _table.selectedRow >= (NSInteger)_matches.count) return;
+	_field.stringValue = [_matches[_table.selectedRow].stringByAbbreviatingWithTildeInPath stringByAppendingString:@"/"];
+	_field.currentEditor.selectedRange = NSMakeRange(_field.stringValue.length, 0);
+	_userPickedRow = NO; // drilled in: back to typed-path mode for the new folder
+	[self updateMatches];
+}
+
+- (void)rowClicked:(id)sender { _userPickedRow = YES; }
+
+- (void)controlTextDidChange:(NSNotification *)n { _userPickedRow = NO; [self updateMatches]; }
+
+- (BOOL)control:(NSControl *)control textView:(NSTextView *)tv doCommandBySelector:(SEL)sel {
+	if (sel == @selector(insertNewline:))    { [self accept:nil];        return YES; }
+	if (sel == @selector(cancelOperation:))  { [self cancel:nil];        return YES; }
+	if (sel == @selector(moveDown:))         { [self moveSelectionBy:1];  return YES; }
+	if (sel == @selector(moveUp:))           { [self moveSelectionBy:-1]; return YES; }
+	if (sel == @selector(insertTab:))        { [self completeSelection];  return YES; }
+	if (sel == @selector(moveRight:)) { // → completes the highlighted folder, but only
+		// at the end of the text so mid-text editing still moves the caret
+		if (NSMaxRange(tv.selectedRange) >= tv.string.length) { [self completeSelection]; return YES; }
+		return NO;
+	}
+	return NO;
+}
+
+- (NSInteger)numberOfRowsInTableView:(NSTableView *)t { return _matches.count; }
+- (id)tableView:(NSTableView *)t objectValueForTableColumn:(NSTableColumn *)c row:(NSInteger)row {
+	return _matches[row].stringByAbbreviatingWithTildeInPath;
+}
+@end
+
 CGFloat DYInterfaceTextScale(void) {
 	NSUserDefaults *u = NSUserDefaults.standardUserDefaults;
 	switch ([u integerForKey:@"interfaceTextSize"]) {
@@ -1277,6 +1445,7 @@ enum {
 	RENAME,
 	DELETE_PERMANENTLY,
 	QUICK_LOOK = 20, // 18=New Window, 19=Select None (tags live only in MainMenu.xib)
+	GO_TO_FOLDER = 24, // 21=Preferences, 22=End Slideshow, 23=Cheat Sheet (tags in MainMenu.xib)
 	JPEG_OP = 100,
 	ROTATE_L = 107,
 	ROTATE_R = 105,
@@ -1368,6 +1537,8 @@ enum {
 			// so it won't hijack SPACE in the slideshow, Prefs, or text fields
 			if (slidesWindow.isMainWindow) return NO;
 			return numSelected > 0 && frontWindow && frontWindow.window.isMainWindow && frontWindow.filenamesDone;
+		case GO_TO_FOLDER:
+			return !slidesWindow.isMainWindow && frontWindow != nil;
 		case SET_DESKTOP:
 			return slidesWindow.isMainWindow
 				? (slidesWindow.currentFile != nil)
@@ -1439,6 +1610,15 @@ enum {
 }
 
 #pragma mark prefs stuff
+- (IBAction)goToFolder:(id)sender {
+	CreeveyMainWindowController *wc = frontWindow;
+	if (!wc) return;
+	NSString *start = wc.path.length ? [wc.path.stringByAbbreviatingWithTildeInPath stringByAppendingString:@"/"] : @"~/";
+	[DYGoToFolderController presentForWindow:wc.window startingPath:start completion:^(NSString *chosen){
+		if (chosen) [wc setPath:chosen];
+	}];
+}
+
 - (IBAction)openPrefWin:(id)sender {
 	if (!prefsWin) {
 		NSArray * __autoreleasing arr;

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -1647,6 +1647,8 @@ enum {
 	SHOW_PATH_BAR = 26,
 	SHOW_UNSUPPORTED = 27,
 	COPY_PATHNAME = 28,
+	SEARCH = 29,
+	SUBFOLDERS = 30,
 	JPEG_OP = 100,
 	ROTATE_L = 107,
 	ROTATE_R = 105,
@@ -1739,6 +1741,11 @@ enum {
 			if (slidesWindow.isMainWindow) return NO;
 			return numSelected > 0 && frontWindow && frontWindow.window.isMainWindow && frontWindow.filenamesDone;
 		case GO_TO_FOLDER:
+			return !slidesWindow.isMainWindow && frontWindow != nil;
+		case SEARCH:
+			return !slidesWindow.isMainWindow && frontWindow != nil;
+		case SUBFOLDERS:
+			menuItem.state = frontWindow.wantsSubfolders;
 			return !slidesWindow.isMainWindow && frontWindow != nil;
 		case COPY_PATHNAME:
 			return !slidesWindow.isMainWindow && numSelected > 0;
@@ -1845,6 +1852,17 @@ enum {
 	if (creeveyWindows.count == 1 || slidesWindow.isMainWindow)
 		[NSUserDefaults.standardUserDefaults setBool:b forKey:@"autoRotateByOrientationTag"];
 	if (!slidesWindow.isMainWindow) [self noteRecentFolderForWindow:frontWindow];
+}
+
+- (IBAction)searchImages:(id)sender {
+	[frontWindow focusSearchField];
+}
+
+- (IBAction)toggleSubfolders:(id)sender {
+	// flip the Subfolders checkbox and run its normal action (sets recurseRoot, reloads)
+	NSButton *b = frontWindow.subfoldersButton;
+	b.state = b.state == NSControlStateValueOn ? NSControlStateValueOff : NSControlStateValueOn;
+	[frontWindow setRecurseSubfolders:b];
 }
 
 #pragma mark prefs stuff

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -526,6 +526,21 @@ static NSModalResponse DYRunAlert(NSAlert *alert) {
 			files = frontWindow.currentSelection;
 		}
 	}
+	if (frontWindow.showUnsupportedFiles) {
+		// the slideshow can't display unsupported files, so drop them from the list; if the
+		// file the user started on is one of them, open it in its default app and bail
+		NSString *startFile = (startIdx != NSNotFound && startIdx < files.count) ? files[startIdx] : nil;
+		if (startFile && ![self shouldShowFile:[NSURL fileURLWithPath:startFile]]) {
+			[NSWorkspace.sharedWorkspace openURL:[NSURL fileURLWithPath:startFile]];
+			return;
+		}
+		NSMutableArray *supported = [NSMutableArray arrayWithCapacity:files.count];
+		for (NSString *p in files)
+			if ([self shouldShowFile:[NSURL fileURLWithPath:p]]) [supported addObject:p];
+		if (!supported.count) return;
+		files = supported;
+		startIdx = startFile ? [files indexOfObject:startFile] : NSNotFound;
+	}
 	if (wantsUpdates) {
 		[slidesWindow setFilenames:files basePath:frontWindow.path wantsSubfolders:frontWindow.wantsSubfolders comparator:frontWindow.comparator sortOrder:frontWindow.sortOrder];
 	} else {
@@ -553,6 +568,20 @@ static NSModalResponse DYRunAlert(NSAlert *alert) {
 }
 
 - (IBAction)openSelectedFiles:(id)sender {
+	// files that the app can't display (shown via "Show Unsupported Files") open in their
+	// default app instead of the slideshow; a mixed selection still starts a slideshow of
+	// the supported files (unsupported ones are filtered out in startSlideshowFullscreen:)
+	NSArray *sel = frontWindow.currentSelection;
+	if (sel.count) {
+		NSMutableArray *unsupported = [NSMutableArray array];
+		for (NSString *p in sel)
+			if (![self shouldShowFile:[NSURL fileURLWithPath:p]]) [unsupported addObject:p];
+		if (unsupported.count == sel.count) {
+			for (NSString *p in unsupported)
+				[NSWorkspace.sharedWorkspace openURL:[NSURL fileURLWithPath:p]];
+			return;
+		}
+	}
 	BOOL fullscreen = [NSUserDefaults.standardUserDefaults integerForKey:@"slideshowDefaultMode"] == 0;
 	if (NSApp.currentEvent.modifierFlags & NSEventModifierFlagOption) fullscreen = !fullscreen;
 	[self startSlideshowFullscreen:fullscreen];
@@ -1449,6 +1478,7 @@ enum {
 	GO_TO_FOLDER = 24, // 21=Preferences, 22=End Slideshow, 23=Cheat Sheet (tags in MainMenu.xib)
 	SHOW_DIRECTORY_BROWSER = 25,
 	SHOW_PATH_BAR = 26,
+	SHOW_UNSUPPORTED = 27,
 	JPEG_OP = 100,
 	ROTATE_L = 107,
 	ROTATE_R = 105,
@@ -1555,6 +1585,10 @@ enum {
 			menuItem.title = frontWindow.imageMatrix.showFilenames ? @"Hide File Names" : @"Show File Names";
 			menuItem.state = NSControlStateValueOff;
 			return !slidesWindow.isMainWindow && frontWindow != nil;
+		case SHOW_UNSUPPORTED:
+			// a content-filter option, so a checkmark (not a Show/Hide verb-swap)
+			menuItem.state = frontWindow.showUnsupportedFiles;
+			return !slidesWindow.isMainWindow && frontWindow != nil;
 		case SET_DESKTOP:
 			return slidesWindow.isMainWindow
 				? (slidesWindow.currentFile != nil)
@@ -1622,6 +1656,11 @@ enum {
 	// the split view persists its own position (MainWindowSplitViewTopHeight), so the
 	// collapsed state is remembered across launches without a separate preference
 	frontWindow.directoryBrowserVisible = !frontWindow.directoryBrowserVisible;
+}
+
+- (IBAction)toggleUnsupportedFiles:(id)sender {
+	// the window re-scans its folder when this flips (see setShowUnsupportedFiles:)
+	frontWindow.showUnsupportedFiles = !frontWindow.showUnsupportedFiles;
 }
 
 - (IBAction)doAutoRotateDisplayedImage:(id)sender {
@@ -2026,6 +2065,16 @@ NSDirectoryEnumerator *CreeveyEnumerator(NSString *path, BOOL recurseSubfolders)
 	NSString *pathExtension = url.pathExtension.lowercaseString;
 	if (pathExtension.length == 0) return [fileostypes containsObject:NSHFSTypeOfFile(path)];
 	return [filetypes containsObject:pathExtension] || ([fileostypes containsObject:NSHFSTypeOfFile(path)] && ![disabledFiletypes containsObject:pathExtension]);
+}
+
+- (BOOL)shouldShowFile:(NSURL *)url includingUnsupported:(BOOL)includeUnsupported {
+	if ([self shouldShowFile:url]) return YES;
+	if (!includeUnsupported) return NO;
+	// admit any other non-hidden file (directories are already handled by the caller); these
+	// can't be shown in-app but can be Quick Looked / opened in their default app
+	NSNumber * __autoreleasing val;
+	if (IS_URL_HIDDEN) return NO;
+	return YES;
 }
 
 - (NSInteger)numberOfRowsInTableView:(NSTableView *)tableView {

--- a/CreeveyController.m
+++ b/CreeveyController.m
@@ -218,7 +218,9 @@ static NSMutableArray *_dyGoToFolderLive; // keep controllers alive while their 
 	_sheet.initialFirstResponder = _field;
 	[self updateMatches];
 	[_parent beginSheet:_sheet completionHandler:^(NSModalResponse r){}];
-	_field.currentEditor.selectedRange = NSMakeRange(_field.stringValue.length, 0);
+	// select the whole path so typing immediately replaces it (Finder-style); press → to
+	// deselect and keep browsing from the current folder
+	_field.currentEditor.selectedRange = NSMakeRange(0, _field.stringValue.length);
 }
 
 - (void)finishWithPath:(NSString *)path {
@@ -1849,7 +1851,10 @@ enum {
 - (IBAction)goToFolder:(id)sender {
 	CreeveyMainWindowController *wc = frontWindow;
 	if (!wc) return;
-	NSString *start = wc.path.length ? [wc.path.stringByAbbreviatingWithTildeInPath stringByAppendingString:@"/"] : @"~/";
+	NSString *abbrev = wc.path.stringByAbbreviatingWithTildeInPath;
+	// append a trailing slash (so the field lists the folder's contents) unless the path is
+	// already slash-terminated, e.g. root "/" — otherwise we'd produce "//"
+	NSString *start = wc.path.length ? ([abbrev hasSuffix:@"/"] ? abbrev : [abbrev stringByAppendingString:@"/"]) : @"~/";
 	[DYGoToFolderController presentForWindow:wc.window startingPath:start completion:^(NSString *chosen){
 		if (chosen) [wc setPath:chosen];
 	}];

--- a/CreeveyMainWindowController.h
+++ b/CreeveyMainWindowController.h
@@ -21,6 +21,7 @@
 
 // accessors
 @property (nonatomic, readonly) NSString *path;
+- (BOOL)setPath:(NSString *)s; // navigate the directory browser to a folder; NO if invalid
 @property (nonatomic, readonly) NSURL *URL;
 @property (nonatomic, readonly) NSArray *currentSelection;
 @property (nonatomic, readonly) NSIndexSet *selectedIndexes;

--- a/CreeveyMainWindowController.h
+++ b/CreeveyMainWindowController.h
@@ -52,6 +52,7 @@
 - (void)openFiles:(NSArray *)a withSlideshow:(BOOL)b;
 - (void)fakeKeyDown:(NSEvent *)e;
 - (void)reloadInterfaceTextSize;
+- (void)focusSearchField; // File > Search: focus the filter field and select its text
 
 // notifiers
 - (void)fileWasChanged:(NSString *)s;

--- a/CreeveyMainWindowController.h
+++ b/CreeveyMainWindowController.h
@@ -40,6 +40,7 @@
 - (void)updateDefaults;
 - (void)openFiles:(NSArray *)a withSlideshow:(BOOL)b;
 - (void)fakeKeyDown:(NSEvent *)e;
+- (void)reloadInterfaceTextSize;
 
 // notifiers
 - (void)fileWasChanged:(NSString *)s;

--- a/CreeveyMainWindowController.h
+++ b/CreeveyMainWindowController.h
@@ -53,6 +53,9 @@
 - (void)fakeKeyDown:(NSEvent *)e;
 - (void)reloadInterfaceTextSize;
 - (void)focusSearchField; // File > Search: focus the filter field and select its text
+- (BOOL)isArchivePath:(NSString *)path; // YES for .zip/.cbz
+- (void)openArchive:(NSString *)zipPath; // extract a .zip to a temp folder and browse it
++ (void)sweepLeftoverArchiveTemps; // delete stale extracted-archive temp dirs (launch/quit only)
 
 // notifiers
 - (void)fileWasChanged:(NSString *)s;

--- a/CreeveyMainWindowController.h
+++ b/CreeveyMainWindowController.h
@@ -40,6 +40,11 @@
 @property (readonly) BOOL wantsSubfolders;
 @property (nonatomic, readonly) DYWrappingMatrix *imageMatrix;
 
+// Open Recent: capture the window's full navigable state, and restore it (navigate +
+// apply sort/toggles + select the remembered file once the async load finishes)
+- (NSDictionary *)currentStateDictionary;
+- (void)restoreState:(NSDictionary *)state;
+
 //other
 - (void)setDefaultPath;
 - (void)updateDefaults;

--- a/CreeveyMainWindowController.h
+++ b/CreeveyMainWindowController.h
@@ -22,6 +22,8 @@
 // accessors
 @property (nonatomic, readonly) NSString *path;
 - (BOOL)setPath:(NSString *)s; // navigate the directory browser to a folder; NO if invalid
+@property (nonatomic) BOOL pathBarVisible;
+@property (nonatomic) BOOL directoryBrowserVisible;
 @property (nonatomic, readonly) NSURL *URL;
 @property (nonatomic, readonly) NSArray *currentSelection;
 @property (nonatomic, readonly) NSIndexSet *selectedIndexes;

--- a/CreeveyMainWindowController.h
+++ b/CreeveyMainWindowController.h
@@ -16,6 +16,7 @@
 @property (weak) IBOutlet NSTextField *statusFld;
 @property (weak) IBOutlet NSTextField *bottomStatusFld;
 @property (weak) IBOutlet NSButton *subfoldersButton;
+@property (weak) IBOutlet NSButton *unsupportedButton;
 
 - (IBAction)setRecurseSubfolders:(id)sender;
 

--- a/CreeveyMainWindowController.h
+++ b/CreeveyMainWindowController.h
@@ -30,6 +30,7 @@
 @property (nonatomic, readonly) NSArray *currentSelection;
 @property (nonatomic, readonly) NSIndexSet *selectedIndexes;
 - (void)selectIndex:(NSUInteger)i;
+- (IBAction)copy:(id)sender; // forwards Cmd-C to the thumbnail grid (also called from the dir browser)
 @property (nonatomic, readonly) NSArray *displayedFilenames;
 - (NSUInteger)indexOfFilename:(NSString *)s;
 @property (nonatomic, readonly) BOOL currentFilesDeletable;

--- a/CreeveyMainWindowController.h
+++ b/CreeveyMainWindowController.h
@@ -24,6 +24,7 @@
 - (BOOL)setPath:(NSString *)s; // navigate the directory browser to a folder; NO if invalid
 @property (nonatomic) BOOL pathBarVisible;
 @property (nonatomic) BOOL directoryBrowserVisible;
+@property (nonatomic) BOOL showUnsupportedFiles;
 @property (nonatomic, readonly) NSURL *URL;
 @property (nonatomic, readonly) NSArray *currentSelection;
 @property (nonatomic, readonly) NSIndexSet *selectedIndexes;

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -12,6 +12,7 @@
 #import "DYFileWatcher.h"
 
 #import "CreeveyController.h"
+#import "KeyBindings.h"
 #import "DYCreeveyBrowser.h"
 #import "DYImageCache.h"
 #import "DYWrappingMatrix.h"
@@ -908,6 +909,21 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 								 toTarget:self
 							   withObject:nil];
 		return;
+	}
+	if (filenamesDone) {
+		switch ([appDelegate.keyBindings browserActionForEvent:e]) {
+			case BrowserActionMoveToTrash:
+				[appDelegate moveToTrash:nil];
+				return;
+			case BrowserActionDeletePermanently:
+				[appDelegate deleteSelectedFilesPermanently:nil];
+				return;
+			case BrowserActionRename:
+				[appDelegate renameSelectedFile:nil];
+				return;
+			case BrowserActionNone:
+				break;
+		}
 	}
 	[super keyDown:e];
 }

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -852,12 +852,13 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 			[filenames removeAllObjects];
 			[self clearImageCacheQueue];
 			BOOL recurseSubfolders = self.wantsSubfolders;
+			BOOL inclUnsupported = self.showUnsupportedFiles;
 			NSDirectoryEnumerator *e = CreeveyEnumerator(thePath, recurseSubfolders);
 			for (NSURL *url in e) {
 				@autoreleasepool {
 					if ([appDelegate handledDirectory:url subfolders:recurseSubfolders e:e])
 						continue;
-					if ([appDelegate shouldShowFile:url]) {
+					if ([appDelegate shouldShowFile:url includingUnsupported:inclUnsupported]) {
 						NSString *aPath = url.path;
 						[filenames addObject:aPath];
 						if (startSlideshowWhenReady && [filesBeingOpened containsObject:aPath])
@@ -1205,6 +1206,12 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 
 - (BOOL)directoryBrowserVisible {
 	return ![self.splitView isSubviewCollapsed:dirBrowser.superview];
+}
+
+- (void)setShowUnsupportedFiles:(BOOL)b {
+	if (b == _showUnsupportedFiles) return;
+	_showUnsupportedFiles = b;
+	[self displayDir:nil]; // re-scan the folder to add or drop the unsupported files
 }
 
 - (void)setDirectoryBrowserVisible:(BOOL)b {

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -214,6 +214,11 @@ typedef struct {
 	NSRegularExpression *_searchRegexCompiled; // compiled query when in regex mode (nil if invalid)
 	NSWindow *_searchTipWindow;          // instant (no-delay) hover tip for the filter field
 	NSTextField *_searchTipField;
+	NSString *_archiveTempDir;           // temp dir a .zip is extracted into while browsing it
+	NSString *_archivePath;              // the original .zip path (remembered in Open Recent)
+	NSString *_archiveDisplayPath;       // clean logical path (zips shown as folders), for the path bar
+	NSString *_archiveDisplayName;       // the .zip's filename, shown as the window title
+	NSProgressIndicator *_archiveSpinner; // shown over the grid while an archive is extracting
 }
 @synthesize dirBrowser, slidesBtn, imgMatrix, statusFld, bottomStatusFld;
 
@@ -453,7 +458,9 @@ typedef struct {
 
 - (void)updatePathBar {
 	if (_pathControl.hidden) return;
-	NSString *p = self.path;
+	// for a mounted archive show the clean logical path (each .zip shown as a folder),
+	// never the raw extraction temp dir
+	NSString *p = _archiveTempDir ? _archiveDisplayPath : self.path;
 	_pathControl.URL = p.length ? [NSURL fileURLWithPath:p] : nil;
 }
 
@@ -560,6 +567,7 @@ typedef struct {
 }
 
 - (void)windowWillClose:(NSNotification *)notification {
+	[self cleanupArchiveTemp]; // don't leave an extracted archive behind
 	[self removeAllPathsFromAccessedFilesArray];
 	imageCacheQueueRunning = NO;
 	[imageCacheQueueLock lock];
@@ -592,10 +600,108 @@ typedef struct {
 		return NO;
 	if (!isDir)
 		s = s.stringByDeletingLastPathComponent;
+	if (_archiveTempDir && ![resolvedPath hasPrefix:_archiveTempDir])
+		[self cleanupArchiveTemp]; // navigated out of a mounted archive — discard its temp files
 	[dirBrowserDelegate setPath:s];
 	[dirBrowser sendAction];
 	[self.window invalidateRestorableState];
 	return YES;
+}
+
+#pragma mark archive (.zip) browsing
+- (BOOL)isArchivePath:(NSString *)path {
+	NSString *ext = path.pathExtension.lowercaseString;
+	return [ext isEqualToString:@"zip"] || [ext isEqualToString:@"cbz"];
+}
+
+// Extract a .zip/.cbz into a temp folder in the background and browse it immediately; the file
+// watcher streams entries into the grid as they extract, and a spinner shows work is ongoing.
+- (void)openArchive:(NSString *)zipPath {
+	NSString *tmp = [NSTemporaryDirectory() stringByAppendingPathComponent:
+		[@"PhoenixSlidesArchive-" stringByAppendingString:NSProcessInfo.processInfo.globallyUniqueString]];
+	if (![NSFileManager.defaultManager createDirectoryAtPath:tmp withIntermediateDirectories:YES attributes:nil error:NULL]) {
+		NSBeep(); return;
+	}
+	tmp = ResolveAliasToPath(tmp); // NSTemporaryDirectory lives under /var → /private/var; resolve so
+	                               // the setPath: cleanup guard below compares like-for-like
+	// Don't delete the previously-mounted archive yet: for a nested archive, zipPath lives *inside*
+	// it, so it must survive until ditto has finished reading it (below). Deleting it up front is
+	// what made "a .zip inside a .zip" extract nothing.
+	NSString *previousTemp = _archiveTempDir;
+	NSString *previousDisplay = _archiveDisplayPath;
+	[self showArchiveSpinner:NO];
+	// Clean logical path for the UI: a nested archive extends the outer archive's display path
+	// (treating each .zip as a folder) so we never surface a raw extraction temp path.
+	if (previousTemp && [zipPath hasPrefix:[previousTemp stringByAppendingString:@"/"]])
+		_archiveDisplayPath = [previousDisplay stringByAppendingString:[zipPath substringFromIndex:previousTemp.length]];
+	else
+		_archiveDisplayPath = zipPath; // top-level archive: its real .zip path
+	_archiveTempDir = tmp;
+	_archivePath = zipPath;
+	_archiveDisplayName = zipPath.lastPathComponent;
+	[self showArchiveSpinner:YES];
+	dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+		NSTask *task = [[NSTask alloc] init];
+		task.executableURL = [NSURL fileURLWithPath:@"/usr/bin/ditto"];
+		task.arguments = @[@"-x", @"-k", zipPath, tmp]; // ditto -x -k = extract PKZip
+		[task launchAndReturnError:NULL];
+		[task waitUntilExit];
+		if (previousTemp) // safe now: we've finished reading zipPath (which may live inside it)
+			[NSFileManager.defaultManager removeItemAtPath:previousTemp error:NULL];
+		dispatch_async(dispatch_get_main_queue(), ^{
+			if ([self->_archiveTempDir isEqualToString:tmp]) { // still viewing this archive
+				[self showArchiveSpinner:NO];
+				[self displayDir:nil]; // final re-scan so nothing extracted early is missed
+			}
+		});
+	});
+	// point the directory browser at the .zip's own folder so the column browser and path bar
+	// agree (the grid itself loads from the temp dir below). Skip when the .zip lives inside an
+	// extraction temp dir — i.e. a nested archive — since that folder isn't a real location.
+	NSString *zipParent = zipPath.stringByDeletingLastPathComponent;
+	if ([zipParent rangeOfString:@"/PhoenixSlidesArchive-"].location == NSNotFound)
+		[dirBrowserDelegate setPath:zipParent]; // updates the browser columns without reloading the grid
+	// browse the temp dir directly via displayDir (the directory browser can't reliably navigate
+	// into a deep hidden temp path); the file watcher streams entries in as they extract
+	[self displayDir:nil];
+}
+
+// Remove every PhoenixSlidesArchive-* temp dir. Safe to call only when no archive is mounted
+// (i.e. at launch or termination); it's the safety net for leftovers from a crash or force-quit.
++ (void)sweepLeftoverArchiveTemps {
+	NSString *tmpRoot = NSTemporaryDirectory();
+	NSFileManager *fm = NSFileManager.defaultManager;
+	for (NSString *name in [fm contentsOfDirectoryAtPath:tmpRoot error:NULL])
+		if ([name hasPrefix:@"PhoenixSlidesArchive-"])
+			[fm removeItemAtPath:[tmpRoot stringByAppendingPathComponent:name] error:NULL];
+}
+
+- (void)cleanupArchiveTemp {
+	[self showArchiveSpinner:NO];
+	if (_archiveTempDir) {
+		[NSFileManager.defaultManager removeItemAtPath:_archiveTempDir error:NULL];
+		_archiveTempDir = nil;
+		_archivePath = nil;
+		_archiveDisplayPath = nil;
+		_archiveDisplayName = nil;
+	}
+}
+
+- (void)showArchiveSpinner:(BOOL)show {
+	if (show && !_archiveSpinner) {
+		_archiveSpinner = [[NSProgressIndicator alloc] init];
+		_archiveSpinner.style = NSProgressIndicatorStyleSpinning;
+		_archiveSpinner.displayedWhenStopped = NO;
+		_archiveSpinner.translatesAutoresizingMaskIntoConstraints = NO;
+		NSView *host = imgMatrix.enclosingScrollView;
+		[host.superview addSubview:_archiveSpinner positioned:NSWindowAbove relativeTo:host];
+		[NSLayoutConstraint activateConstraints:@[
+			[_archiveSpinner.centerXAnchor constraintEqualToAnchor:host.centerXAnchor],
+			[_archiveSpinner.centerYAnchor constraintEqualToAnchor:host.centerYAnchor],
+		]];
+	}
+	if (show) [_archiveSpinner startAnimation:nil];
+	else [_archiveSpinner stopAnimation:nil];
 }
 
 - (void)setDefaultPath {
@@ -636,13 +742,24 @@ typedef struct {
 #pragma mark Open Recent state
 // Snapshot the window's full navigable state (nil if no folder is loaded yet).
 - (NSDictionary *)currentStateDictionary {
-	NSString *unresolved = dirBrowserDelegate.unresolvedPath;
-	if (!unresolved.length) return nil;
-	NSString *focused = imgMatrix.firstSelectedFilename;
 	NSMutableDictionary *d = [NSMutableDictionary dictionary];
-	d[@"path"] = ResolveAliasToPath(unresolved);            // resolved: identity / existence
-	d[@"displayPath"] = unresolved.stringByAbbreviatingWithTildeInPath; // ~-abbreviated: menu title
-	d[@"focusedFile"] = focused ?: @"";
+	if (_archiveTempDir) {
+		// a nested archive's source .zip lives in a temp dir that won't survive — don't record it
+		// (it could never be reopened, and its path is ugly)
+		if ([_archivePath rangeOfString:@"/PhoenixSlidesArchive-"].location != NSNotFound) return nil;
+		// a mounted archive is remembered by its .zip path and re-extracted when reopened
+		d[@"isArchive"] = @YES;
+		d[@"path"] = ResolveAliasToPath(_archivePath);
+		d[@"displayPath"] = _archivePath.stringByAbbreviatingWithTildeInPath;
+		d[@"focusedFile"] = @""; // temp-dir paths don't survive a remount
+	} else {
+		NSString *unresolved = dirBrowserDelegate.unresolvedPath;
+		if (!unresolved.length) return nil;
+		NSString *focused = imgMatrix.firstSelectedFilename;
+		d[@"path"] = ResolveAliasToPath(unresolved);            // resolved: identity / existence
+		d[@"displayPath"] = unresolved.stringByAbbreviatingWithTildeInPath; // ~-abbreviated: menu title
+		d[@"focusedFile"] = focused ?: @"";
+	}
 	d[@"sortOrder"] = @(sortOrder);
 	d[@"wantsSubfolders"] = @(self.wantsSubfolders);
 	if (self.recurseRoot) d[@"recurseRoot"] = self.recurseRoot;
@@ -672,6 +789,10 @@ typedef struct {
 	if ([e[@"cellWidth"] floatValue] > 0) imgMatrix.cellWidth = [e[@"cellWidth"] floatValue];
 	self.pathBarVisible = [e[@"pathBarVisible"] boolValue];
 	self.directoryBrowserVisible = [e[@"directoryBrowserVisible"] boolValue];
+	if ([e[@"isArchive"] boolValue]) { // re-extract and browse the .zip
+		[self openArchive:e[@"path"]];
+		return;
+	}
 	// navigate + select the remembered file after the async load (reuses openFiles:)
 	NSString *focused = e[@"focusedFile"];
 	if ([focused isKindOfClass:NSString.class] && focused.length)
@@ -811,6 +932,10 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 }
 
 - (void)openFiles:(NSArray *)a withSlideshow:(BOOL)doSlides{
+	if (a.count == 1 && [self isArchivePath:a[0]]) { // dragged/opened a .zip — browse its contents
+		[self openArchive:a[0]];
+		return;
+	}
 	startSlideshowWhenReady = doSlides;
 	[filesBeingOpened addObjectsFromArray:a];
 	BOOL isDir;
@@ -1229,7 +1354,16 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 	currCat = 0;
 	if (_searchQuery.length) { _searchQuery = nil; _searchField.stringValue = @""; } // filter is per-folder; clear on navigation
 	slidesBtn.enabled = NO;
-	NSString *currentPath = [dirBrowserDelegate path];
+	// A mounted archive is browsed straight from its temp dir (the NSBrowser can't reliably
+	// navigate into a deep hidden temp path). Our own refresh calls pass sender==nil; a non-nil
+	// sender means the user drove the directory browser, i.e. navigated out of the archive.
+	NSString *currentPath;
+	if (_archiveTempDir && sender == nil) {
+		currentPath = _archiveTempDir;
+	} else {
+		if (_archiveTempDir) [self cleanupArchiveTemp]; // user navigated the browser → leave the archive
+		currentPath = [dirBrowserDelegate path];
+	}
 	_subfoldersButton.enabled = ![currentPath isEqualToString:@"/"]; // let's not ever load up the entire file system
 	if (self.wantsSubfolders && sender) { // sender is dirBrowserDelegate when non-nil
 		if (![currentPath hasPrefix:_recurseRoot]) {
@@ -1238,7 +1372,10 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 		}
 	}
 	[self updateStatusString:NSLocalizedString(@"Getting filenames...", @"")];
-	[self.window setTitleWithRepresentedFilename:currentPath];
+	if (_archiveTempDir && sender == nil && _archiveDisplayName)
+		self.window.title = _archiveDisplayName; // show the archive name, not the temp path
+	else
+		[self.window setTitleWithRepresentedFilename:currentPath];
 	[self updatePathBar];
 	[NSThread detachNewThreadSelector:@selector(loadImages:)
 							 toTarget:self withObject:currentPath];
@@ -1568,8 +1705,14 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 						pixelSize = NSZeroSize;
 				}
 			}
-			NSUInteger idx = [dirBrowserDelegate path].length+1;
-			NSString *fileName = idx > path.length ? path : [path substringFromIndex:idx];
+			// show the file's name relative to the folder being browsed; for an archive that's
+			// the extraction temp dir, not the directory browser's path. If the file isn't under
+			// that base (e.g. a transient/other-archive entry), fall back to the bare filename so
+			// we never surface a raw temp-path fragment.
+			NSString *base = _archiveTempDir ?: [dirBrowserDelegate path];
+			NSString *fileName = [path hasPrefix:[base stringByAppendingString:@"/"]]
+				? [path substringFromIndex:base.length+1]
+				: path.lastPathComponent;
 			s = [fileName stringByAppendingFormat:@" %dx%d (%@)",
 				 (int)pixelSize.width, (int)pixelSize.height, FileSize2String(fileSize)];
 		} else {

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -322,8 +322,15 @@ typedef struct {
 // Instant hover tip for the filter field (the system tool tip's delay hides the regex option).
 - (void)mouseEntered:(NSEvent *)e { [self showSearchTip]; }
 - (void)mouseExited:(NSEvent *)e { [_searchTipWindow orderOut:nil]; }
+- (void)windowDidResignKey:(NSNotification *)n { [_searchTipWindow orderOut:nil]; } // don't linger when unfocused
+
+- (BOOL)mouseIsOverSearchField {
+	NSPoint p = [_searchField convertPoint:self.window.mouseLocationOutsideOfEventStream fromView:nil];
+	return NSMouseInRect(p, _searchField.bounds, _searchField.isFlipped);
+}
 
 - (void)showSearchTip {
+	if (![self mouseIsOverSearchField]) { [_searchTipWindow orderOut:nil]; return; } // only when truly hovering the field
 	if (!_searchTipWindow) {
 		NSView *bg = [[NSView alloc] initWithFrame:NSZeroRect];
 		bg.wantsLayer = YES;

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -19,6 +19,7 @@
 #import <sys/stat.h>
 #include <sys/attr.h>
 #import "DYExiftags.h"
+@import Quartz; // QLPreviewPanel
 
 @implementation NSString (DateModifiedCompare)
 
@@ -159,7 +160,7 @@ typedef struct {
 @end
 
 
-@interface CreeveyMainWindowController () <DYFileWatcherDelegate>
+@interface CreeveyMainWindowController () <DYFileWatcherDelegate, QLPreviewPanelDataSource, QLPreviewPanelDelegate>
 @property (nonatomic, readonly) NSSplitView *splitView;
 @property BOOL wantsSubfolders;
 @property (nonatomic, strong) NSString *recurseRoot;
@@ -399,6 +400,49 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 }
 - (void)selectIndex:(NSUInteger)i {
 	[imgMatrix selectIndex:i];
+}
+
+#pragma mark Quick Look panel
+
+- (BOOL)acceptsPreviewPanelControl:(QLPreviewPanel *)panel {
+	return filenamesDone && displayedFilenames.count > 0;
+}
+
+- (void)beginPreviewPanelControl:(QLPreviewPanel *)panel {
+	panel.delegate = self;
+	panel.dataSource = self;
+	NSUInteger sel = imgMatrix.selectedIndexes.firstIndex;
+	panel.currentPreviewItemIndex = (sel == NSNotFound) ? 0 : sel;
+}
+
+- (void)endPreviewPanelControl:(QLPreviewPanel *)panel {
+	panel.delegate = nil;
+	panel.dataSource = nil;
+}
+
+- (NSInteger)numberOfPreviewItemsInPreviewPanel:(QLPreviewPanel *)panel {
+	return displayedFilenames.count;
+}
+
+- (id <QLPreviewItem>)previewPanel:(QLPreviewPanel *)panel previewItemAtIndex:(NSInteger)index {
+	if (index < 0 || index >= (NSInteger)displayedFilenames.count) return nil;
+	return [NSURL fileURLWithPath:ResolveAliasToPath(displayedFilenames[index])];
+}
+
+// Forward the arrow keys to the grid so it tracks the panel in lock-step;
+// closing Quick Look then leaves the browsed image selected (Finder-style).
+- (BOOL)previewPanel:(QLPreviewPanel *)panel handleEvent:(NSEvent *)event {
+	if (event.type == NSEventTypeKeyDown && event.characters.length) {
+		unichar c = [event.characters characterAtIndex:0];
+		if (c == NSLeftArrowFunctionKey || c == NSRightArrowFunctionKey ||
+			c == NSUpArrowFunctionKey || c == NSDownArrowFunctionKey) {
+			[imgMatrix keyDown:event];
+			NSUInteger sel = imgMatrix.selectedIndexes.firstIndex;
+			if (sel != NSNotFound) panel.currentPreviewItemIndex = sel;
+			return YES;
+		}
+	}
+	return NO;
 }
 
 - (void)openFiles:(NSArray *)a withSlideshow:(BOOL)doSlides{

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -208,6 +208,10 @@ typedef struct {
 	BOOL _directoryBrowserHidden;        // YES when only the control strip shows (browser hidden)
 	NSLayoutConstraint *_browserMinHeight, *_browserGap, *_browserZeroHeight;
 	BOOL _quickLookActive;               // YES while the Quick Look panel has control
+	NSSearchField *_searchField;         // filters the displayed thumbnails by filename
+	NSString *_searchQuery;              // current filter text ("" / nil = no filter)
+	BOOL _searchRegex;                   // treat the query as a regular expression
+	NSRegularExpression *_searchRegexCompiled; // compiled query when in regex mode (nil if invalid)
 }
 @synthesize dirBrowser, slidesBtn, imgMatrix, statusFld, bottomStatusFld;
 
@@ -260,6 +264,92 @@ typedef struct {
 	[NSUserDefaultsController.sharedUserDefaultsController addObserver:self forKeyPath:@"values.DYWrappingMatrixMaxCellWidth" options:0 context:NULL];
 	[self applyInterfaceTextSize];
 	[self setupPathBar];
+	[self setupSearchField];
+}
+
+#pragma mark search field
+// A filename filter in the control strip: statusFld | search | Unsupported | Subfolders | Slideshow.
+// Regex mode lives in the magnifier's menu (the strip has no room for another checkbox).
+- (void)setupSearchField {
+	NSView *pane = statusFld.superview;
+	_searchField = [[NSSearchField alloc] initWithFrame:NSZeroRect];
+	_searchField.translatesAutoresizingMaskIntoConstraints = NO;
+	_searchField.controlSize = NSControlSizeSmall;
+	_searchField.font = [NSFont systemFontOfSize:NSFont.smallSystemFontSize];
+	((NSSearchFieldCell *)_searchField.cell).placeholderString = NSLocalizedString(@"Filter", @"");
+	_searchField.sendsWholeSearchString = NO;
+	_searchField.sendsSearchStringImmediately = NO; // debounce a touch while typing
+	_searchField.target = self;
+	_searchField.action = @selector(searchFieldChanged:);
+	NSMenu *menu = [[NSMenu alloc] initWithTitle:@""];
+	NSMenuItem *rx = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"Regular Expression", @"")
+												action:@selector(toggleSearchRegex:) keyEquivalent:@""];
+	rx.target = self;
+	rx.tag = 1;
+	[menu addItem:rx];
+	_searchField.searchMenuTemplate = menu; // magnifier dropdown → Regex toggle
+	[statusFld setContentCompressionResistancePriority:250 forOrientation:NSLayoutConstraintOrientationHorizontal]; // let the count text yield to the field
+	[pane addSubview:_searchField];
+	// splice the field into the row between the status text and the Unsupported checkbox
+	for (NSLayoutConstraint *c in pane.constraints.copy)
+		if (c.firstItem == self.unsupportedButton && c.firstAttribute == NSLayoutAttributeLeading &&
+			c.secondItem == statusFld && c.secondAttribute == NSLayoutAttributeTrailing) {
+			c.active = NO; break;
+		}
+	NSLayoutConstraint *preferredWidth = [_searchField.widthAnchor constraintEqualToConstant:160];
+	preferredWidth.priority = 250; // grow to ~160 if there's room, shrink otherwise
+	[NSLayoutConstraint activateConstraints:@[
+		[_searchField.leadingAnchor constraintEqualToAnchor:statusFld.trailingAnchor constant:8],
+		[self.unsupportedButton.leadingAnchor constraintEqualToAnchor:_searchField.trailingAnchor constant:8],
+		[_searchField.centerYAnchor constraintEqualToAnchor:self.unsupportedButton.centerYAnchor],
+		[_searchField.widthAnchor constraintGreaterThanOrEqualToConstant:70],
+		preferredWidth,
+	]];
+}
+
+- (IBAction)searchFieldChanged:(id)sender {
+	NSString *q = _searchField.stringValue;
+	_searchQuery = q.length ? q : nil;
+	[self recompileSearch];
+	[self refilter];
+}
+
+- (IBAction)toggleSearchRegex:(id)sender {
+	_searchRegex = !_searchRegex;
+	[self recompileSearch];
+	[self refilter];
+}
+
+// checkmark the "Regular Expression" item when the magnifier menu opens
+- (BOOL)validateMenuItem:(NSMenuItem *)menuItem {
+	if (menuItem.action == @selector(toggleSearchRegex:)) {
+		menuItem.state = _searchRegex ? NSControlStateValueOn : NSControlStateValueOff;
+		return YES;
+	}
+	return YES;
+}
+
+- (void)recompileSearch {
+	_searchRegexCompiled = nil;
+	if (_searchRegex && _searchQuery.length)
+		_searchRegexCompiled = [NSRegularExpression regularExpressionWithPattern:_searchQuery
+																		 options:NSRegularExpressionCaseInsensitive error:NULL];
+}
+
+// Re-filter the already-loaded files without re-reading the disk (same path loadImages: takes for sort/category).
+- (void)refilter {
+	[NSThread detachNewThreadSelector:@selector(loadImages:) toTarget:self withObject:nil];
+}
+
+// YES if a filename passes the current filter (no filter → always YES).
+- (BOOL)filenamePassesSearch:(NSString *)path {
+	if (!_searchQuery.length) return YES;
+	NSString *name = path.lastPathComponent;
+	if (_searchRegex) {
+		if (!_searchRegexCompiled) return YES; // invalid pattern: don't hide anything
+		return [_searchRegexCompiled numberOfMatchesInString:name options:0 range:NSMakeRange(0, name.length)] > 0;
+	}
+	return [name rangeOfString:_searchQuery options:NSCaseInsensitiveSearch].location != NSNotFound;
 }
 
 #pragma mark path bar
@@ -967,6 +1057,12 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 		} else {
 			[displayedFilenames setArray:filenames];
 		}
+		if (_searchQuery.length) { // filename filter (regex or case-insensitive substring)
+			NSMutableArray *filtered = [NSMutableArray arrayWithCapacity:displayedFilenames.count];
+			for (NSString *path in displayedFilenames)
+				if ([self filenamePassesSearch:path]) [filtered addObject:path];
+			[displayedFilenames setArray:filtered];
+		}
 		time(&matrixModTime);
 		if (startSlideshowWhenReady) {
 			startSlideshowWhenReady = NO;
@@ -1059,6 +1155,7 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 	currentFilesDeletable = NO;
 	filenamesDone = NO;
 	currCat = 0;
+	if (_searchQuery.length) { _searchQuery = nil; _searchField.stringValue = @""; } // filter is per-folder; clear on navigation
 	slidesBtn.enabled = NO;
 	NSString *currentPath = [dirBrowserDelegate path];
 	_subfoldersButton.enabled = ![currentPath isEqualToString:@"/"]; // let's not ever load up the entire file system

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -851,6 +851,11 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 
 
 #pragma mark event stuff
+- (void)reloadInterfaceTextSize {
+	[imgMatrix reloadTextSize];
+	[dirBrowser reloadTextSize];
+}
+
 - (void)fakeKeyDown:(NSEvent *)e {
 	[self.window makeFirstResponder:imgMatrix];
 	[imgMatrix keyDown:e];

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -361,6 +361,11 @@ typedef struct {
 {
 	if ([keyPath isEqualToString:@"values.DYWrappingMatrixMaxCellWidth"]) {
 		_maxCellWidth = [NSUserDefaults.standardUserDefaults integerForKey:@"DYWrappingMatrixMaxCellWidth"];
+	} else if ([keyPath isEqualToString:@"currentPreviewItemIndex"]) {
+		// Quick Look changed its current item (e.g. its own left/right nav) — follow it in the grid
+		NSInteger idx = ((QLPreviewPanel *)object).currentPreviewItemIndex;
+		if (idx >= 0 && idx < (NSInteger)displayedFilenames.count && imgMatrix.selectedIndexes.firstIndex != (NSUInteger)idx)
+			[self selectIndex:idx];
 	}
 }
 
@@ -518,9 +523,13 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 	panel.dataSource = self;
 	NSUInteger sel = imgMatrix.selectedIndexes.firstIndex;
 	panel.currentPreviewItemIndex = (sel == NSNotFound) ? 0 : sel;
+	// Quick Look navigates left/right itself (those keys never reach handleEvent:), so watch
+	// its index and mirror it in the grid to keep the highlighted thumbnail in lock-step
+	[panel addObserver:self forKeyPath:@"currentPreviewItemIndex" options:0 context:NULL];
 }
 
 - (void)endPreviewPanelControl:(QLPreviewPanel *)panel {
+	[panel removeObserver:self forKeyPath:@"currentPreviewItemIndex"];
 	panel.delegate = nil;
 	panel.dataSource = nil;
 }

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -307,6 +307,12 @@ typedef struct {
 	]];
 }
 
+// Focus the filter field, selecting any existing text so it can be retyped or edited.
+- (void)focusSearchField {
+	[self.window makeFirstResponder:_searchField];
+	[_searchField selectText:nil];
+}
+
 - (IBAction)searchFieldChanged:(id)sender {
 	NSString *q = _searchField.stringValue;
 	_searchQuery = q.length ? q : nil;

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -437,17 +437,51 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 // Forward the arrow keys to the grid so it tracks the panel in lock-step;
 // closing Quick Look then leaves the browsed image selected (Finder-style).
 - (BOOL)previewPanel:(QLPreviewPanel *)panel handleEvent:(NSEvent *)event {
-	if (event.type == NSEventTypeKeyDown && event.characters.length) {
-		unichar c = [event.characters characterAtIndex:0];
-		if (c == NSLeftArrowFunctionKey || c == NSRightArrowFunctionKey ||
-			c == NSUpArrowFunctionKey || c == NSDownArrowFunctionKey) {
-			[imgMatrix keyDown:event];
-			NSUInteger sel = imgMatrix.selectedIndexes.firstIndex;
-			if (sel != NSNotFound) panel.currentPreviewItemIndex = sel;
-			return YES;
-		}
+	if (event.type != NSEventTypeKeyDown || event.characters.length == 0) return NO;
+	unichar c = [event.characters characterAtIndex:0];
+	// arrow keys: move the grid selection and keep the panel in sync
+	if (c == NSLeftArrowFunctionKey || c == NSRightArrowFunctionKey ||
+		c == NSUpArrowFunctionKey || c == NSDownArrowFunctionKey) {
+		[imgMatrix keyDown:event];
+		NSUInteger sel = imgMatrix.selectedIndexes.firstIndex;
+		if (sel != NSNotFound) panel.currentPreviewItemIndex = sel;
+		return YES;
+	}
+	NSEventModifierFlags mods = event.modifierFlags &
+		(NSEventModifierFlagCommand|NSEventModifierFlagControl|NSEventModifierFlagOption);
+	if (mods == 0) {
+		// unmodified single-key browser actions (trash / delete / rename), per the
+		// config; leave Space, Esc, Return, etc. for Quick Look itself
+		if ([appDelegate.keyBindings browserActionForEvent:event] == BrowserActionNone)
+			return NO;
+		[self keyDown:event];
+		[self reloadQuickLook:panel];
+		return YES;
+	}
+	// keep window/app-management keys with Quick Look and the system, so the browser
+	// window isn't closed/minimized/hidden out from under the preview
+	if ((mods & NSEventModifierFlagCommand) && event.charactersIgnoringModifiers.length == 1
+		&& [@"wmhqnt" containsString:event.charactersIgnoringModifiers.lowercaseString])
+		return NO;
+	// forward every other shortcut to the app's menu (Get Info, Reveal, Rotate, Set
+	// Desktop, Move/Copy To, Sort, …), then refresh in case the file list changed
+	if ([NSApp.mainMenu performKeyEquivalent:event]) {
+		[self reloadQuickLook:panel];
+		return YES;
 	}
 	return NO;
+}
+
+// after a Quick Look action that may have trashed/renamed/reordered files, refresh
+// the panel and follow the grid selection (or close the panel if nothing remains)
+- (void)reloadQuickLook:(QLPreviewPanel *)panel {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		if (!panel.isVisible) return;
+		if (displayedFilenames.count == 0) { [panel orderOut:nil]; return; }
+		[panel reloadData];
+		NSUInteger sel = imgMatrix.selectedIndexes.firstIndex;
+		panel.currentPreviewItemIndex = (sel == NSNotFound) ? 0 : MIN(sel, displayedFilenames.count - 1);
+	});
 }
 
 // zoom the panel open from (and closed to) the thumbnail, for immediate feedback

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -207,6 +207,7 @@ typedef struct {
 	BOOL _togglingBrowser;               // set while show/hide runs, to protect _savedBrowserHeight
 	BOOL _directoryBrowserHidden;        // YES when only the control strip shows (browser hidden)
 	NSLayoutConstraint *_browserMinHeight, *_browserGap, *_browserZeroHeight;
+	BOOL _quickLookActive;               // YES while the Quick Look panel has control
 }
 @synthesize dirBrowser, slidesBtn, imgMatrix, statusFld, bottomStatusFld;
 
@@ -523,6 +524,8 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 - (void)beginPreviewPanelControl:(QLPreviewPanel *)panel {
 	panel.delegate = self;
 	panel.dataSource = self;
+	_quickLookActive = YES; // suppress the browser's per-selection status/EXIF work; it's hidden behind the panel
+	imgMatrix.selectionUpdatesSuppressed = YES; // and don't scroll/redraw the hidden grid (avoids background thumbnailing that competes with quicklookd)
 	NSUInteger sel = imgMatrix.selectedIndexes.firstIndex;
 	panel.currentPreviewItemIndex = (sel == NSNotFound) ? 0 : sel;
 	// Quick Look navigates left/right itself (those keys never reach handleEvent:), so watch
@@ -534,6 +537,14 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 	[panel removeObserver:self forKeyPath:@"currentPreviewItemIndex"];
 	panel.delegate = nil;
 	panel.dataSource = nil;
+	_quickLookActive = NO;
+	imgMatrix.selectionUpdatesSuppressed = NO;
+	[imgMatrix setNeedsDisplay:YES]; // clear any stale highlight left while suppressed
+	NSUInteger i = imgMatrix.selectedIndexes.firstIndex;
+	if (i != NSNotFound)
+		[imgMatrix selectIndex:i]; // scroll the landed image into view and refresh status/EXIF
+	else
+		[self wrappingMatrixSelectionDidChange:imgMatrix.selectedIndexes];
 }
 
 - (NSInteger)numberOfPreviewItemsInPreviewPanel:(QLPreviewPanel *)panel {
@@ -1280,6 +1291,10 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 
 #pragma mark wrapping matrix methods
 - (void)wrappingMatrixSelectionDidChange:(NSIndexSet *)selectedIndexes {
+	// While Quick Look is up, the status line and Get Info panel are hidden behind it, so skip
+	// this work (it can decode an image just to report its dimensions). endPreviewPanelControl
+	// calls us once when the panel closes to refresh for the file we landed on.
+	if (_quickLookActive) return;
 	NSString *s;
 	NSUInteger count = selectedIndexes.count;
 	if (count == 0) {

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -476,6 +476,53 @@ typedef struct {
 }
 
 
+#pragma mark Open Recent state
+// Snapshot the window's full navigable state (nil if no folder is loaded yet).
+- (NSDictionary *)currentStateDictionary {
+	NSString *unresolved = dirBrowserDelegate.unresolvedPath;
+	if (!unresolved.length) return nil;
+	NSString *focused = imgMatrix.firstSelectedFilename;
+	NSMutableDictionary *d = [NSMutableDictionary dictionary];
+	d[@"path"] = ResolveAliasToPath(unresolved);            // resolved: identity / existence
+	d[@"displayPath"] = unresolved.stringByAbbreviatingWithTildeInPath; // ~-abbreviated: menu title
+	d[@"focusedFile"] = focused ?: @"";
+	d[@"sortOrder"] = @(sortOrder);
+	d[@"wantsSubfolders"] = @(self.wantsSubfolders);
+	if (self.recurseRoot) d[@"recurseRoot"] = self.recurseRoot;
+	d[@"showUnsupportedFiles"] = @(_showUnsupportedFiles);
+	d[@"showFilenames"] = @(imgMatrix.showFilenames);
+	d[@"autoRotate"] = @(imgMatrix.autoRotate);
+	d[@"directoryBrowserVisible"] = @(self.directoryBrowserVisible);
+	d[@"browserHeight"] = @(_savedBrowserHeight);
+	d[@"pathBarVisible"] = @(self.pathBarVisible);
+	d[@"cellWidth"] = @(imgMatrix.cellWidth);
+	return d;
+}
+
+// Apply a saved state: set list-affecting bits first (no reload), then navigate once and
+// let the loader select the remembered file, then apply the view-only toggles.
+- (void)restoreState:(NSDictionary *)e {
+	if (e[@"sortOrder"]) self.sortOrder = [e[@"sortOrder"] shortValue];
+	self.recurseRoot = e[@"recurseRoot"]; // may be nil
+	[self setWantsSubfolders:[e[@"wantsSubfolders"] boolValue]];
+	self.subfoldersButton.state = self.wantsSubfolders ? NSControlStateValueOn : NSControlStateValueOff;
+	_showUnsupportedFiles = [e[@"showUnsupportedFiles"] boolValue]; // direct: avoid a redundant reload
+	self.unsupportedButton.state = _showUnsupportedFiles ? NSControlStateValueOn : NSControlStateValueOff;
+	// view-only toggles (no directory reload needed)
+	if ([e[@"browserHeight"] doubleValue] > 0) _savedBrowserHeight = [e[@"browserHeight"] doubleValue];
+	imgMatrix.showFilenames = [e[@"showFilenames"] boolValue];
+	imgMatrix.autoRotate = [e[@"autoRotate"] boolValue];
+	if ([e[@"cellWidth"] floatValue] > 0) imgMatrix.cellWidth = [e[@"cellWidth"] floatValue];
+	self.pathBarVisible = [e[@"pathBarVisible"] boolValue];
+	self.directoryBrowserVisible = [e[@"directoryBrowserVisible"] boolValue];
+	// navigate + select the remembered file after the async load (reuses openFiles:)
+	NSString *focused = e[@"focusedFile"];
+	if ([focused isKindOfClass:NSString.class] && focused.length)
+		[self openFiles:@[focused] withSlideshow:NO];
+	else
+		[self setPath:e[@"path"]];
+}
+
 - (BOOL)currentFilesDeletable { return currentFilesDeletable; }
 - (BOOL)filenamesDone { return filenamesDone; }
 - (NSArray *)displayedFilenames { return displayedFilenames; }
@@ -931,6 +978,7 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 		}
 		filenamesDone = YES;
 		//NSLog(@"got %d files.", [filenames count]);
+		dispatch_async(dispatch_get_main_queue(), ^{ [appDelegate noteRecentFolderForWindow:self]; }); // Open Recent: record the folder we just loaded
 	}
 #pragma mark populate matrix
 	@autoreleasepool {
@@ -1360,6 +1408,7 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 	}
 	bottomStatusFld.stringValue = s;
 	[self updateExifInfo];
+	[appDelegate noteRecentFolderForWindow:self]; // Open Recent: keep the folder's focused-file current
 }
 
 - (NSImage *)wrappingMatrixWantsImageForFile:(NSString *)filename atIndex:(NSUInteger)i {

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -937,11 +937,16 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 
 - (void)updateStatusFld {
 	id s = NSLocalizedString(@"%u images", @"");
-	NSString *status = currCat
-		? [NSString stringWithFormat:@"%@: %@",
+	NSString *status;
+	if (currCat)
+		status = [NSString stringWithFormat:@"%@: %@",
 			[NSString stringWithFormat:NSLocalizedString(@"Group %i", @""), currCat],
-			[NSString stringWithFormat:s, displayedFilenames.count]]
-		: [NSString stringWithFormat:s, filenames.count];
+			[NSString stringWithFormat:s, displayedFilenames.count]];
+	else if (_searchQuery.length) // filtering: show matches of the folder total
+		status = [NSString stringWithFormat:NSLocalizedString(@"%u of %u images", @""),
+			(unsigned)displayedFilenames.count, (unsigned)filenames.count];
+	else
+		status = [NSString stringWithFormat:s, filenames.count];
 	[self updateStatusString:status];
 }
 

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -450,6 +450,13 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 	return NO;
 }
 
+// zoom the panel open from (and closed to) the thumbnail, for immediate feedback
+- (NSRect)previewPanel:(QLPreviewPanel *)panel sourceFrameOnScreenForPreviewItem:(id <QLPreviewItem>)item {
+	NSInteger idx = panel.currentPreviewItemIndex;
+	if (idx < 0 || idx >= (NSInteger)displayedFilenames.count) return NSZeroRect;
+	return [imgMatrix screenRectForCellAtIndex:idx];
+}
+
 - (void)openFiles:(NSArray *)a withSlideshow:(BOOL)doSlides{
 	startSlideshowWhenReady = doSlides;
 	[filesBeingOpened addObjectsFromArray:a];
@@ -1161,6 +1168,9 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 	DYMatrixState *currState = [[DYMatrixState alloc] init];
 	while (YES) {
 		@autoreleasepool {
+			// decode at higher priority for the window the user is looking at, and
+			// lower for background windows, so the visible grid fills in first
+			NSThread.currentThread.qualityOfService = _background ? NSQualityOfServiceUtility : NSQualityOfServiceUserInitiated;
 			// all calls to the thumbnail view must be on the main thread, which we wait for synchronously
 			// to avoid a deadlock (where the view's drawRect calls our loadImageForFile, which modifies the cache queue),
 			// we save the state of the view before acquiring the lock (we can't use NSRecursiveLock since we need NSConditionLock)

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -200,6 +200,11 @@ typedef struct {
 	// base (design) font sizes for the controls we scale with the interface text size
 	CGFloat _statusBaseSize, _bottomStatusBaseSize;
 	BOOL _textBasesCaptured;
+
+	NSPathControl *_pathControl;         // Finder-style path bar at the bottom
+	NSLayoutConstraint *_pathBarHeight;  // toggled between a row height and 0 to show/hide
+	CGFloat _savedBrowserHeight;         // last non-zero directory-browser height, for restore
+	BOOL _togglingBrowser;               // set while show/hide runs, to protect _savedBrowserHeight
 }
 @synthesize dirBrowser, slidesBtn, imgMatrix, statusFld, bottomStatusFld;
 
@@ -251,6 +256,101 @@ typedef struct {
 	[NSThread detachNewThreadSelector:@selector(thumbLoader:) toTarget:self withObject:nil];
 	[NSUserDefaultsController.sharedUserDefaultsController addObserver:self forKeyPath:@"values.DYWrappingMatrixMaxCellWidth" options:0 context:NULL];
 	[self applyInterfaceTextSize];
+	[self setupPathBar];
+}
+
+#pragma mark path bar
+// Add a Finder-style NSPathControl across the bottom of the window and re-pin the
+// split view's bottom to it (it was pinned to the window's bottom).
+- (void)setupPathBar {
+	NSScrollView *scroll = imgMatrix.enclosingScrollView; // the thumbnail grid's scroll view
+	NSView *pane = scroll.superview;                       // the split view's bottom pane
+	NSView *status = bottomStatusFld;                      // the file-info + slider row
+	_pathControl = [[NSPathControl alloc] initWithFrame:NSZeroRect];
+	_pathControl.translatesAutoresizingMaskIntoConstraints = NO;
+	_pathControl.pathStyle = NSPathStyleStandard;
+	_pathControl.focusRingType = NSFocusRingTypeNone;
+	_pathControl.target = self;
+	_pathControl.action = @selector(pathBarClicked:);
+	[pane addSubview:_pathControl positioned:NSWindowBelow relativeTo:status];
+	// the status row's top is pinned to the grid's bottom; slot the path bar between them
+	for (NSLayoutConstraint *c in pane.constraints.copy) {
+		BOOL statusToGrid =
+			(c.firstItem == status && c.firstAttribute == NSLayoutAttributeTop && c.secondItem == scroll) ||
+			(c.firstItem == scroll && c.firstAttribute == NSLayoutAttributeBottom && c.secondItem == status);
+		if (statusToGrid) { c.active = NO; break; }
+	}
+	_pathBarHeight = [_pathControl.heightAnchor constraintEqualToConstant:0];
+	[NSLayoutConstraint activateConstraints:@[
+		[_pathControl.leadingAnchor constraintEqualToAnchor:pane.leadingAnchor],
+		[_pathControl.trailingAnchor constraintEqualToAnchor:pane.trailingAnchor],
+		[_pathControl.topAnchor constraintEqualToAnchor:scroll.bottomAnchor],
+		[status.topAnchor constraintEqualToAnchor:_pathControl.bottomAnchor constant:1],
+		_pathBarHeight,
+	]];
+	[self setPathBarVisible:[NSUserDefaults.standardUserDefaults boolForKey:@"showPathBar"]];
+}
+
+- (void)updatePathBar {
+	if (_pathControl.hidden) return;
+	NSString *p = self.path;
+	_pathControl.URL = p.length ? [NSURL fileURLWithPath:p] : nil;
+}
+
+- (void)pathBarClicked:(NSPathControl *)sender {
+	NSURL *u = sender.clickedPathItem.URL;
+	if (!u) return;
+	if (NSApp.currentEvent.modifierFlags & NSEventModifierFlagShift)
+		[self showSubfolderMenuForURL:u inControl:sender]; // Finder-style: list that folder's sub-folders
+	else
+		[self setPath:u.path];
+}
+
+- (void)showSubfolderMenuForURL:(NSURL *)dir inControl:(NSPathControl *)control {
+	NSFileManager *fm = NSFileManager.defaultManager;
+	NSArray<NSURL *> *contents = [fm contentsOfDirectoryAtURL:dir
+								  includingPropertiesForKeys:@[NSURLIsDirectoryKey]
+													 options:NSDirectoryEnumerationSkipsHiddenFiles error:NULL];
+	NSMutableArray<NSURL *> *subdirs = [NSMutableArray array];
+	for (NSURL *u in contents) {
+		NSNumber *isDir = nil;
+		[u getResourceValue:&isDir forKey:NSURLIsDirectoryKey error:NULL];
+		if (isDir.boolValue) [subdirs addObject:u];
+	}
+	[subdirs sortUsingComparator:^NSComparisonResult(NSURL *a, NSURL *b){
+		return [a.lastPathComponent localizedStandardCompare:b.lastPathComponent];
+	}];
+	NSMenu *menu = [[NSMenu alloc] init];
+	for (NSURL *u in subdirs) {
+		NSMenuItem *mi = [[NSMenuItem alloc] initWithTitle:u.lastPathComponent
+													action:@selector(goToSubfolder:) keyEquivalent:@""];
+		mi.target = self;
+		mi.representedObject = u.path;
+		NSImage *icon = [NSWorkspace.sharedWorkspace iconForFile:u.path];
+		icon.size = NSMakeSize(16, 16);
+		mi.image = icon;
+		[menu addItem:mi];
+	}
+	if (menu.numberOfItems == 0) {
+		NSMenuItem *none = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"No Folders", @"") action:NULL keyEquivalent:@""];
+		none.enabled = NO;
+		[menu addItem:none];
+	}
+	NSEvent *e = NSApp.currentEvent;
+	NSPoint p = e ? [control convertPoint:e.locationInWindow fromView:nil] : NSMakePoint(0, control.bounds.size.height);
+	[menu popUpMenuPositioningItem:nil atLocation:p inView:control];
+}
+
+- (void)goToSubfolder:(NSMenuItem *)sender {
+	[self setPath:sender.representedObject];
+}
+
+- (BOOL)pathBarVisible { return _pathBarHeight.constant > 0; }
+
+- (void)setPathBarVisible:(BOOL)b {
+	_pathBarHeight.constant = b ? 24 : 0;
+	_pathControl.hidden = !b;
+	[self updatePathBar];
 }
 
 - (void)dealloc {
@@ -899,6 +999,7 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 	}
 	[self updateStatusString:NSLocalizedString(@"Getting filenames...", @"")];
 	[self.window setTitleWithRepresentedFilename:currentPath];
+	[self updatePathBar];
 	[NSThread detachNewThreadSelector:@selector(loadImages:)
 							 toTarget:self withObject:currentPath];
 }
@@ -1097,6 +1198,27 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 {
 	float height = statusFld.superview.hidden ? 0 : statusFld.superview.frame.size.height;
 	[NSUserDefaults.standardUserDefaults setFloat:height forKey:@"MainWindowSplitViewTopHeight"];
+	// remember heights from real user drags only; the show/hide toggle sets _togglingBrowser
+	// so the intermediate resize as the pane clamps to its minimum can't clobber the saved size
+	if (height > 0 && !_togglingBrowser) _savedBrowserHeight = height;
+}
+
+- (BOOL)directoryBrowserVisible {
+	return ![self.splitView isSubviewCollapsed:dirBrowser.superview];
+}
+
+- (void)setDirectoryBrowserVisible:(BOOL)b {
+	if (b == self.directoryBrowserVisible) return;
+	_togglingBrowser = YES; // guard _savedBrowserHeight against the collapse's own resize passes
+	if (b) {
+		CGFloat h = _savedBrowserHeight > 0 ? _savedBrowserHeight : 151;
+		[self.splitView setPosition:h ofDividerAtIndex:0];
+	} else {
+		CGFloat h = dirBrowser.superview.frame.size.height; // remember the size before collapsing
+		if (h > 0) _savedBrowserHeight = h;
+		[self.splitView setPosition:0 ofDividerAtIndex:0]; // 0 collapses (canCollapseSubview allows it)
+	}
+	dispatch_async(dispatch_get_main_queue(), ^{ self->_togglingBrowser = NO; }); // clear after this cycle's resizes
 }
 
 -(BOOL)splitView:(NSSplitView *)splitView canCollapseSubview:(NSView *)subview {

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -210,6 +210,7 @@ typedef struct {
 	BOOL _quickLookActive;               // YES while the Quick Look panel has control
 	NSSearchField *_searchField;         // filters the displayed thumbnails by filename
 	NSString *_searchQuery;              // current filter text ("" / nil = no filter)
+	NSString *_lastLoadedPath;           // folder the filter applies to; changing it clears the filter
 	BOOL _searchRegex;                   // treat the query as a regular expression
 	NSRegularExpression *_searchRegexCompiled; // compiled query when in regex mode (nil if invalid)
 	NSWindow *_searchTipWindow;          // instant (no-delay) hover tip for the filter field
@@ -1352,7 +1353,6 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 	currentFilesDeletable = NO;
 	filenamesDone = NO;
 	currCat = 0;
-	if (_searchQuery.length) { _searchQuery = nil; _searchField.stringValue = @""; } // filter is per-folder; clear on navigation
 	slidesBtn.enabled = NO;
 	// A mounted archive is browsed straight from its temp dir (the NSBrowser can't reliably
 	// navigate into a deep hidden temp path). Our own refresh calls pass sender==nil; a non-nil
@@ -1363,6 +1363,12 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 	} else {
 		if (_archiveTempDir) [self cleanupArchiveTemp]; // user navigated the browser → leave the archive
 		currentPath = [dirBrowserDelegate path];
+	}
+	// the filter is per-folder: clear it only on a real folder change, not on same-folder
+	// re-scans (toggling Unsupported/Subfolders, etc.)
+	if (![currentPath isEqualToString:_lastLoadedPath]) {
+		if (_searchQuery.length) { _searchQuery = nil; _searchField.stringValue = @""; }
+		_lastLoadedPath = currentPath;
 	}
 	_subfoldersButton.enabled = ![currentPath isEqualToString:@"/"]; // let's not ever load up the entire file system
 	if (self.wantsSubfolders && sender) { // sender is dirBrowserDelegate when non-nil

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -205,6 +205,8 @@ typedef struct {
 	NSLayoutConstraint *_pathBarHeight;  // toggled between a row height and 0 to show/hide
 	CGFloat _savedBrowserHeight;         // last non-zero directory-browser height, for restore
 	BOOL _togglingBrowser;               // set while show/hide runs, to protect _savedBrowserHeight
+	BOOL _directoryBrowserHidden;        // YES when only the control strip shows (browser hidden)
+	NSLayoutConstraint *_browserMinHeight, *_browserGap, *_browserZeroHeight;
 }
 @synthesize dirBrowser, slidesBtn, imgMatrix, statusFld, bottomStatusFld;
 
@@ -1206,6 +1208,9 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 
 - (void)splitViewDidResizeSubviews:(NSNotification *)notification
 {
+	// only persist/remember the height while the browser is actually shown — when it's
+	// hidden the pane is shrunk to the control strip, which isn't a height worth restoring
+	if (_directoryBrowserHidden) return;
 	float height = statusFld.superview.hidden ? 0 : statusFld.superview.frame.size.height;
 	[NSUserDefaults.standardUserDefaults setFloat:height forKey:@"MainWindowSplitViewTopHeight"];
 	// remember heights from real user drags only; the show/hide toggle sets _togglingBrowser
@@ -1214,25 +1219,57 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 }
 
 - (BOOL)directoryBrowserVisible {
-	return ![self.splitView isSubviewCollapsed:dirBrowser.superview];
+	return !_directoryBrowserHidden;
+}
+
+// The directory browser and the control strip (file count, Unsupported/Subfolders, Slideshow)
+// share the top split pane. To keep the strip visible when the browser is hidden, we drop just
+// the browser view and shrink the pane to the strip, instead of collapsing the whole pane.
+- (void)ensureBrowserToggleConstraints {
+	if (_browserZeroHeight) return;
+	NSView *pane = dirBrowser.superview;
+	for (NSLayoutConstraint *c in dirBrowser.constraints)
+		if (c.firstItem == dirBrowser && c.firstAttribute == NSLayoutAttributeHeight && c.relation == NSLayoutRelationGreaterThanOrEqual)
+			_browserMinHeight = c; // browser's height >= 30
+	for (NSLayoutConstraint *c in pane.constraints)
+		if (c.firstItem == slidesBtn && c.firstAttribute == NSLayoutAttributeTop && c.secondItem == dirBrowser && c.secondAttribute == NSLayoutAttributeBottom)
+			_browserGap = c; // control strip sits below the browser
+	_browserZeroHeight = [dirBrowser.heightAnchor constraintEqualToConstant:0]; // inactive until hidden
 }
 
 - (void)setShowUnsupportedFiles:(BOOL)b {
 	if (b == _showUnsupportedFiles) return;
 	_showUnsupportedFiles = b;
+	_unsupportedButton.state = b ? NSControlStateValueOn : NSControlStateValueOff; // sync the checkbox (menu-driven toggles land here too)
 	[self displayDir:nil]; // re-scan the folder to add or drop the unsupported files
 }
 
-- (void)setDirectoryBrowserVisible:(BOOL)b {
-	if (b == self.directoryBrowserVisible) return;
-	_togglingBrowser = YES; // guard _savedBrowserHeight against the collapse's own resize passes
-	if (b) {
+- (IBAction)toggleUnsupportedFilesButton:(id)sender {
+	self.showUnsupportedFiles = ([(NSButton *)sender state] == NSControlStateValueOn);
+}
+
+- (void)setDirectoryBrowserVisible:(BOOL)show {
+	if (show == !_directoryBrowserHidden) return;
+	[self ensureBrowserToggleConstraints];
+	_directoryBrowserHidden = !show;
+	_togglingBrowser = YES; // guard _savedBrowserHeight against the resize passes below
+	NSView *pane = dirBrowser.superview;
+	if (show) {
+		dirBrowser.hidden = NO;
+		_browserZeroHeight.active = NO;
+		_browserGap.active = YES;
+		_browserMinHeight.active = YES;
 		CGFloat h = _savedBrowserHeight > 0 ? _savedBrowserHeight : 151;
 		[self.splitView setPosition:h ofDividerAtIndex:0];
 	} else {
-		CGFloat h = dirBrowser.superview.frame.size.height; // remember the size before collapsing
-		if (h > 0) _savedBrowserHeight = h;
-		[self.splitView setPosition:0 ofDividerAtIndex:0]; // 0 collapses (canCollapseSubview allows it)
+		// keep the control strip: hide only the browser and shrink the pane to the strip below it
+		CGFloat strip = pane.frame.size.height - dirBrowser.frame.size.height;
+		if (pane.frame.size.height > strip) _savedBrowserHeight = pane.frame.size.height;
+		dirBrowser.hidden = YES;
+		_browserMinHeight.active = NO; // let the browser go to zero height
+		_browserGap.active = NO;       // unlink the strip from the (now hidden) browser
+		_browserZeroHeight.active = YES;
+		[self.splitView setPosition:strip ofDividerAtIndex:0];
 	}
 	dispatch_async(dispatch_get_main_queue(), ^{ self->_togglingBrowser = NO; }); // clear after this cycle's resizes
 }

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -212,6 +212,8 @@ typedef struct {
 	NSString *_searchQuery;              // current filter text ("" / nil = no filter)
 	BOOL _searchRegex;                   // treat the query as a regular expression
 	NSRegularExpression *_searchRegexCompiled; // compiled query when in regex mode (nil if invalid)
+	NSWindow *_searchTipWindow;          // instant (no-delay) hover tip for the filter field
+	NSTextField *_searchTipField;
 }
 @synthesize dirBrowser, slidesBtn, imgMatrix, statusFld, bottomStatusFld;
 
@@ -277,6 +279,10 @@ typedef struct {
 	_searchField.controlSize = NSControlSizeRegular;
 	_searchField.font = [NSFont systemFontOfSize:NSFont.systemFontSize];
 	((NSSearchFieldCell *)_searchField.cell).placeholderString = NSLocalizedString(@"Filter", @"");
+	// instant (no system delay) hover tip explaining the regex option; see mouseEntered:/showSearchTip
+	[_searchField addTrackingArea:[[NSTrackingArea alloc] initWithRect:NSZeroRect
+		options:NSTrackingMouseEnteredAndExited|NSTrackingActiveInKeyWindow|NSTrackingInVisibleRect
+		owner:self userInfo:nil]];
 	_searchField.sendsWholeSearchString = NO;
 	_searchField.sendsSearchStringImmediately = NO; // debounce a touch while typing
 	_searchField.target = self;
@@ -313,7 +319,51 @@ typedef struct {
 	[_searchField selectText:nil];
 }
 
+// Instant hover tip for the filter field (the system tool tip's delay hides the regex option).
+- (void)mouseEntered:(NSEvent *)e { [self showSearchTip]; }
+- (void)mouseExited:(NSEvent *)e { [_searchTipWindow orderOut:nil]; }
+
+- (void)showSearchTip {
+	if (!_searchTipWindow) {
+		NSView *bg = [[NSView alloc] initWithFrame:NSZeroRect];
+		bg.wantsLayer = YES;
+		bg.layer.cornerRadius = 4;
+		bg.layer.borderWidth = 0.5;
+		_searchTipField = [NSTextField labelWithString:@""];
+		_searchTipField.font = [NSFont toolTipsFontOfSize:0];
+		[bg addSubview:_searchTipField];
+		_searchTipWindow = [[NSWindow alloc] initWithContentRect:NSZeroRect styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:NO];
+		_searchTipWindow.opaque = NO;
+		_searchTipWindow.backgroundColor = NSColor.clearColor;
+		_searchTipWindow.hasShadow = YES;
+		_searchTipWindow.level = NSPopUpMenuWindowLevel;
+		_searchTipWindow.ignoresMouseEvents = YES;
+		_searchTipWindow.contentView = bg;
+	}
+	_searchTipWindow.appearance = self.window.effectiveAppearance;
+	NSView *bg = _searchTipWindow.contentView;
+	bg.layer.backgroundColor = NSColor.controlBackgroundColor.CGColor;
+	bg.layer.borderColor = [NSColor.gridColor colorWithAlphaComponent:0.8].CGColor;
+	_searchTipField.textColor = NSColor.controlTextColor;
+	_searchTipField.stringValue = NSLocalizedString(@"Type to filter by name; click the magnifier for a regular-expression option.", @"");
+	[_searchTipField sizeToFit];
+	const CGFloat padX = 6, padY = 3;
+	NSSize fs = _searchTipField.frame.size;
+	_searchTipField.frameOrigin = NSMakePoint(padX, padY);
+	NSRect wf = NSMakeRect(0, 0, ceil(fs.width) + padX*2, ceil(fs.height) + padY*2);
+	NSRect field = [self.window convertRectToScreen:[_searchField convertRect:_searchField.bounds toView:nil]];
+	wf.origin.x = round(NSMinX(field));
+	wf.origin.y = round(NSMinY(field) - wf.size.height - 3); // just below the field
+	NSRect vis = (self.window.screen ?: NSScreen.mainScreen).visibleFrame;
+	if (NSMaxX(wf) > NSMaxX(vis)) wf.origin.x = NSMaxX(vis) - wf.size.width;
+	if (wf.origin.x < NSMinX(vis)) wf.origin.x = NSMinX(vis);
+	if (wf.origin.y < NSMinY(vis)) wf.origin.y = round(NSMaxY(field) + 3); // flip above if no room below
+	[_searchTipWindow setFrame:wf display:YES];
+	[_searchTipWindow orderFront:nil];
+}
+
 - (IBAction)searchFieldChanged:(id)sender {
+	[_searchTipWindow orderOut:nil]; // dismiss the hint once the user starts typing
 	NSString *q = _searchField.stringValue;
 	_searchQuery = q.length ? q : nil;
 	[self recompileSearch];

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -274,8 +274,8 @@ typedef struct {
 	NSView *pane = statusFld.superview;
 	_searchField = [[NSSearchField alloc] initWithFrame:NSZeroRect];
 	_searchField.translatesAutoresizingMaskIntoConstraints = NO;
-	_searchField.controlSize = NSControlSizeSmall;
-	_searchField.font = [NSFont systemFontOfSize:NSFont.smallSystemFontSize];
+	_searchField.controlSize = NSControlSizeRegular;
+	_searchField.font = [NSFont systemFontOfSize:NSFont.systemFontSize];
 	((NSSearchFieldCell *)_searchField.cell).placeholderString = NSLocalizedString(@"Filter", @"");
 	_searchField.sendsWholeSearchString = NO;
 	_searchField.sendsSearchStringImmediately = NO; // debounce a touch while typing

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -484,13 +484,6 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 	});
 }
 
-// zoom the panel open from (and closed to) the thumbnail, for immediate feedback
-- (NSRect)previewPanel:(QLPreviewPanel *)panel sourceFrameOnScreenForPreviewItem:(id <QLPreviewItem>)item {
-	NSInteger idx = panel.currentPreviewItemIndex;
-	if (idx < 0 || idx >= (NSInteger)displayedFilenames.count) return NSZeroRect;
-	return [imgMatrix screenRectForCellAtIndex:idx];
-}
-
 - (void)openFiles:(NSArray *)a withSlideshow:(BOOL)doSlides{
 	startSlideshowWhenReady = doSlides;
 	[filesBeingOpened addObjectsFromArray:a];

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -196,6 +196,10 @@ typedef struct {
 	NSLock *_accessedLock, *_internalLock;
 	_Atomic(NSTimeInterval) _statusTime;
 	DYFileWatcher *_fileWatcher;
+
+	// base (design) font sizes for the controls we scale with the interface text size
+	CGFloat _statusBaseSize, _bottomStatusBaseSize;
+	BOOL _textBasesCaptured;
 }
 @synthesize dirBrowser, slidesBtn, imgMatrix, statusFld, bottomStatusFld;
 
@@ -246,6 +250,7 @@ typedef struct {
 	imgMatrix.loadingImage = _loadingImage;
 	[NSThread detachNewThreadSelector:@selector(thumbLoader:) toTarget:self withObject:nil];
 	[NSUserDefaultsController.sharedUserDefaultsController addObserver:self forKeyPath:@"values.DYWrappingMatrixMaxCellWidth" options:0 context:NULL];
+	[self applyInterfaceTextSize];
 }
 
 - (void)dealloc {
@@ -898,6 +903,20 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 - (void)reloadInterfaceTextSize {
 	[imgMatrix reloadTextSize];
 	[dirBrowser reloadTextSize];
+	[self applyInterfaceTextSize];
+}
+
+// scale the window's status line and file-info line with the interface text
+// size setting. Base sizes are captured once so repeated changes don't compound.
+- (void)applyInterfaceTextSize {
+	if (!_textBasesCaptured) {
+		_statusBaseSize = statusFld.font.pointSize;
+		_bottomStatusBaseSize = bottomStatusFld.font.pointSize;
+		_textBasesCaptured = YES;
+	}
+	CGFloat s = DYInterfaceTextScale();
+	statusFld.font = [NSFont fontWithDescriptor:statusFld.font.fontDescriptor size:_statusBaseSize * s];
+	bottomStatusFld.font = [NSFont fontWithDescriptor:bottomStatusFld.font.fontDescriptor size:_bottomStatusBaseSize * s];
 }
 
 - (void)fakeKeyDown:(NSEvent *)e {

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -426,6 +426,10 @@ typedef struct {
 	_pathControl.translatesAutoresizingMaskIntoConstraints = NO;
 	_pathControl.pathStyle = NSPathStyleStandard;
 	_pathControl.focusRingType = NSFocusRingTypeNone;
+	// a long path (e.g. a nested archive) must never widen the window or block shrinking it;
+	// let the control be compressed so it truncates/collapses segments to fit, like Finder
+	[_pathControl setContentCompressionResistancePriority:NSLayoutPriorityDefaultLow-1 forOrientation:NSLayoutConstraintOrientationHorizontal];
+	[_pathControl setContentHuggingPriority:NSLayoutPriorityDefaultLow forOrientation:NSLayoutConstraintOrientationHorizontal];
 	_pathControl.target = self;
 	_pathControl.action = @selector(pathBarClicked:);
 	[pane addSubview:_pathControl positioned:NSWindowBelow relativeTo:status];

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -1448,8 +1448,20 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 	// this work (it can decode an image just to report its dimensions). endPreviewPanelControl
 	// calls us once when the panel closes to refresh for the file we landed on.
 	if (_quickLookActive) return;
+	// Coalesce the heavy work below (summing sizes stat()s every selected file; EXIF; the Open
+	// Recent note) so a rapid multi-select — mouse drag or shift+arrow — doesn't do O(files)
+	// syscalls on each change. A single/empty selection is cheap, so refresh it immediately.
+	[NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(updateSelectionInfo) object:nil];
+	if (selectedIndexes.count > 1)
+		[self performSelector:@selector(updateSelectionInfo) withObject:nil afterDelay:0.12];
+	else
+		[self updateSelectionInfo];
+}
+
+- (void)updateSelectionInfo {
+	if (_quickLookActive) return;
 	NSString *s;
-	NSUInteger count = selectedIndexes.count;
+	NSUInteger count = imgMatrix.selectedIndexes.count;
 	if (count == 0) {
 		s = @"";
 	} else {
@@ -1507,7 +1519,7 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 				}
 			}
 			s = [NSString stringWithFormat:@"%@ (%@)",
-				 [NSString stringWithFormat:NSLocalizedString(@"%d images selected.", @""), (unsigned int)selectedIndexes.count],
+				 [NSString stringWithFormat:NSLocalizedString(@"%d images selected.", @""), (unsigned int)count],
 				 FileSize2String(totalSize)];
 		}
 	}

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -1026,11 +1026,17 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 }
 
 - (void)addFile:(NSString *)s atIndex:(NSUInteger)idx {
-	if (displayedFilenames.count == filenames.count) {
-		[displayedFilenames insertObject:s atIndex:idx];
-		[imgMatrix addImage:nil withFilename:s atIndex:idx];
-	}
 	[filenames insertObject:s atIndex:idx];
+	// show it in the grid too — but when a filter or category is active, only if it belongs there,
+	// inserted at the sort-correct spot within the (possibly smaller) displayed list
+	BOOL shows = [self filenamePassesSearch:s] &&
+		(currCat == 0 || (currCat >= 2 && [appDelegate.cats[currCat-2] containsObject:s]));
+	if (shows) {
+		NSUInteger didx = [displayedFilenames indexOfObject:s inSortedRange:NSMakeRange(0, displayedFilenames.count)
+											options:NSBinarySearchingInsertionIndex usingComparator:self.comparator];
+		[displayedFilenames insertObject:s atIndex:didx];
+		[imgMatrix addImage:nil withFilename:s atIndex:didx];
+	}
 	[self updateStatusFld];
 }
 

--- a/CreeveyMainWindowController.m
+++ b/CreeveyMainWindowController.m
@@ -1197,6 +1197,9 @@ NSComparator ComparatorForSortOrder(short sortOrder) {
 
 
 #pragma mark menu stuff
+- (void)copy:(id)sender {
+	[imgMatrix copy:sender]; // so Cmd-C copies the grid selection even from the directory browser
+}
 - (void)selectAll:(id)sender{
 	[self.window makeFirstResponder:imgMatrix];
 	[imgMatrix selectAll:sender];

--- a/DYCreeveyBrowser.h
+++ b/DYCreeveyBrowser.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 // supports separate display/underlying paths
 @interface DYCreeveyBrowser : NSBrowser
 @property (nullable, weak) id<DYCreeveyBrowserDelegate> delegate;
+- (void)reloadTextSize; // re-apply the interface text size
 @end
 
 NS_ASSUME_NONNULL_END

--- a/DYCreeveyBrowser.m
+++ b/DYCreeveyBrowser.m
@@ -58,11 +58,16 @@ CGFloat DYInterfaceTextScale(void); // defined in CreeveyController.m
 @implementation DYCreeveyBrowserMatrix
 - (BOOL)validateMenuItem:(NSMenuItem *)menuItem {
 	if (menuItem.action == @selector(selectAll:)) return YES;
+	if (menuItem.action == @selector(copy:))
+		return [(CreeveyMainWindowController *)self.window.delegate selectedIndexes].count > 0;
 	if ([menuItem.target isKindOfClass:[DYCreeveyBrowser class]]) return YES;
 	return [super validateMenuItem:menuItem];
 }
 - (void)selectAll:(id)sender {
 	[(CreeveyMainWindowController *)self.window.delegate selectAll:sender]; // to pass it to image matrix
+}
+- (void)copy:(id)sender {
+	[(CreeveyMainWindowController *)self.window.delegate copy:sender]; // pass Cmd-C through to the image matrix
 }
 - (void)keyDown:(NSEvent *)e {
 	unichar c = 0;

--- a/DYCreeveyBrowser.m
+++ b/DYCreeveyBrowser.m
@@ -9,6 +9,8 @@
 #import "CreeveyMainWindowController.h"
 #import "DYCarbonGoodies.h"
 
+CGFloat DYInterfaceTextScale(void); // defined in CreeveyController.m
+
 @interface DYCreeveyBrowser ()
 @property (nonatomic, strong) NSMenu *contextMenu;
 @end
@@ -137,7 +139,7 @@
 		self.titled = NO;
 		self.hasHorizontalScroller = YES;
 		[self setCellClass:[DYBrowserCell class]];
-		[self.cellPrototype setFont:[NSFont systemFontOfSize:NSFont.smallSystemFontSize]];
+		[self applyInterfaceTextSize];
 		self.allowsEmptySelection = NO;
 		self.columnResizingType = NSBrowserUserColumnResizing;
 		self.prefersAllColumnUserResizing = NO;
@@ -145,6 +147,34 @@
 		[self registerForDraggedTypes:@[NSPasteboardTypeFileURL]];
 	}
 	return self;
+}
+
+- (void)applyInterfaceTextSize {
+	// font only — this runs during initWithFrame: (nib instantiation). Setting rowHeight
+	// here (or in awakeFromNib) crashes: the browser isn't configured enough to re-tile
+	// until it's actually loaded and displayed. rowHeight is set later, in reloadTextSize.
+	[self.cellPrototype setFont:[NSFont systemFontOfSize:NSFont.smallSystemFontSize * DYInterfaceTextScale()]];
+}
+
+- (void)reloadTextSize {
+	// Legacy matrix mode: NSBrowser.rowHeight and restoring selectionIndexPath after a
+	// column reload both crash. So instead we update the font on the already-loaded cells
+	// directly and resize each column's rows to fit — no reload, no selection change.
+	[self applyInterfaceTextSize]; // updates the prototype for future columns
+	NSFont *font = [self.cellPrototype font];
+	CGFloat rowHeight = ceil([self.cellPrototype cellSize].height);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+	for (NSInteger col = 0; col <= self.lastColumn; ++col) {
+		NSMatrix *m = [self matrixInColumn:col];
+		for (NSCell *cell in m.cells)
+			[cell setFont:font];
+		[m setCellSize:NSMakeSize(m.cellSize.width, rowHeight)];
+		[m sizeToCells];
+		[m setNeedsDisplay:YES];
+	}
+#pragma GCC diagnostic pop
+	[self tile];
 }
 
 - (BOOL)sendAction {

--- a/DYFileWatcher.h
+++ b/DYFileWatcher.h
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol DYFileWatcherDelegate <NSObject>
 - (void)watcherFiles:(NSArray *)files deleted:(NSArray *)deleted;
 - (void)watcherRootChanged:(NSURL *)fileRef;
+@property (nonatomic, readonly) BOOL showUnsupportedFiles;
 @end
 
 @interface DYFileWatcher : NSObject

--- a/DYFileWatcher.m
+++ b/DYFileWatcher.m
@@ -73,7 +73,7 @@ static void fseventCallback(ConstFSEventStreamRef streamRef, void *info, size_t 
 			if (f & kFSEventStreamEventFlagItemIsDir) continue;
 			if (_wantsSubfolders ? [s hasPrefix:_path] : [s.stringByDeletingLastPathComponent isEqualToString:_path]) {
 				NSURL *url = [NSURL fileURLWithPath:s isDirectory:NO];
-				if (![appDelegate shouldShowFile:url]) continue;
+				if (![appDelegate shouldShowFile:url includingUnsupported:_delegate.showUnsupportedFiles]) continue;
 				if (0 == access(s.fileSystemRepresentation, R_OK))
 					[files addObject:s];
 				else

--- a/DYImageCache.m
+++ b/DYImageCache.m
@@ -10,6 +10,7 @@
 #import "DYImageCache.h"
 #import "DYCarbonGoodies.h"
 #import <sys/stat.h>
+@import QuickLookThumbnailing;
 
 #define N_StringFromFileSize_UNITS 3
 NSString *FileSize2String(unsigned long long fileSize) {
@@ -415,6 +416,27 @@ static void ScaleCGImage(CGImageSourceRef orig, CGSize boundingSize, DYImageInfo
 	}
 }
 
+// Ask Quick Look for a thumbnail when our own decoders can't render a file.
+// Runs on the background thumbnail thread, so blocking on the async generator is fine.
+static NSImage *DYQuickLookThumbnail(NSString *path, NSSize boundingSize) {
+	if (boundingSize.width < 1 || boundingSize.height < 1) return nil;
+	QLThumbnailGenerationRequest *req = [[QLThumbnailGenerationRequest alloc]
+		initWithFileAtURL:[NSURL fileURLWithPath:path]
+					 size:boundingSize
+					scale:1.0
+	  representationTypes:QLThumbnailGenerationRequestRepresentationTypeAll];
+	NSMutableArray<NSImage *> *holder = [NSMutableArray array]; // heap-retained by the block, so it stays safe if we time out
+	dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+	[QLThumbnailGenerator.sharedGenerator generateBestRepresentationForRequest:req
+		completionHandler:^(QLThumbnailRepresentation *rep, NSError *error) {
+			if (rep.NSImage) [holder addObject:rep.NSImage];
+			dispatch_semaphore_signal(sem);
+		}];
+	if (dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(8 * NSEC_PER_SEC))) != 0)
+		return nil; // timed out
+	return holder.firstObject;
+}
+
 - (void)createScaledImage:(DYImageInfo *)imgInfo {
 	if (imgInfo->fileSize == 0)
 		return;  // nsimage crashes on zero-length files
@@ -464,6 +486,16 @@ static void ScaleCGImage(CGImageSourceRef orig, CGSize boundingSize, DYImageInfo
 		if (orig) {
 			ScaleCGImage(orig, boundingSize, imgInfo, _fastThumbnails);
 			CFRelease(orig);
+		}
+	}
+	if (!imgInfo.image) {
+		// our decoders couldn't render it (e.g. an unsupported file shown via the
+		// browser's "Show Unsupported Files" toggle) — fall back to a Quick Look thumbnail
+		NSImage *ql = DYQuickLookThumbnail(path, boundingSize);
+		if (ql) {
+			imgInfo.image = ql;
+			imgInfo->pixelSize = ql.size;
+			imgInfo->quality = DYImageQualityFull;
 		}
 	}
 }

--- a/DYImageCache.m
+++ b/DYImageCache.m
@@ -418,7 +418,7 @@ static void ScaleCGImage(CGImageSourceRef orig, CGSize boundingSize, DYImageInfo
 
 // Ask Quick Look for a thumbnail when our own decoders can't render a file.
 // Runs on the background thumbnail thread, so blocking on the async generator is fine.
-static NSImage *DYQuickLookThumbnail(NSString *path, NSSize boundingSize) {
+static NSImage *QuickLookThumbnail(NSString *path, NSSize boundingSize) {
 	if (boundingSize.width < 1 || boundingSize.height < 1) return nil;
 	QLThumbnailGenerationRequest *req = [[QLThumbnailGenerationRequest alloc]
 		initWithFileAtURL:[NSURL fileURLWithPath:path]
@@ -491,7 +491,7 @@ static NSImage *DYQuickLookThumbnail(NSString *path, NSSize boundingSize) {
 	if (!imgInfo.image) {
 		// our decoders couldn't render it (e.g. an unsupported file shown via the
 		// browser's "Show Unsupported Files" toggle) — fall back to a Quick Look thumbnail
-		NSImage *ql = DYQuickLookThumbnail(path, boundingSize);
+		NSImage *ql = QuickLookThumbnail(path, boundingSize);
 		if (ql) {
 			imgInfo.image = ql;
 			imgInfo->pixelSize = ql.size;

--- a/DYWrappingMatrix.h
+++ b/DYWrappingMatrix.h
@@ -63,6 +63,7 @@
 - (void)selectFilenames:(NSArray *)arr comparator:(NSComparator)cmp;
 - (void)selectIndex:(NSUInteger)i;
 - (void)scrollToFirstSelected:(NSIndexSet *)x;
+- (NSRect)screenRectForCellAtIndex:(NSUInteger)i; // thumbnail rect in screen coords, or NSZeroRect if off-screen
 
 @property (nonatomic, readonly) NSUInteger numCells;
 

--- a/DYWrappingMatrix.h
+++ b/DYWrappingMatrix.h
@@ -61,6 +61,7 @@
 @property (nonatomic, readonly) NSString *firstSelectedFilename;
 - (IBAction)selectAll:(id)sender;
 - (IBAction)selectNone:(id)sender;
+- (IBAction)copy:(id)sender;
 - (void)selectFilenames:(NSArray *)arr comparator:(NSComparator)cmp;
 - (void)selectIndex:(NSUInteger)i;
 - (void)scrollToFirstSelected:(NSIndexSet *)x;

--- a/DYWrappingMatrix.h
+++ b/DYWrappingMatrix.h
@@ -74,6 +74,7 @@
 @property (nonatomic, readonly) float minCellWidth;
 @property (nonatomic) float cellWidth;
 
+- (void)reloadTextSize; // re-apply the interface text size to file-name labels
 @property (nonatomic) BOOL showFilenames;
 @property (nonatomic) BOOL autoRotate;
 

--- a/DYWrappingMatrix.h
+++ b/DYWrappingMatrix.h
@@ -63,7 +63,6 @@
 - (void)selectFilenames:(NSArray *)arr comparator:(NSComparator)cmp;
 - (void)selectIndex:(NSUInteger)i;
 - (void)scrollToFirstSelected:(NSIndexSet *)x;
-- (NSRect)screenRectForCellAtIndex:(NSUInteger)i; // thumbnail rect in screen coords, or NSZeroRect if off-screen
 
 @property (nonatomic, readonly) NSUInteger numCells;
 

--- a/DYWrappingMatrix.h
+++ b/DYWrappingMatrix.h
@@ -41,6 +41,7 @@
 @property (weak) IBOutlet id delegate;
 @property (weak, nonatomic) NSImage *loadingImage;
 @property (nonatomic) NSColor *imageBackgroundColor;
+@property (nonatomic) BOOL selectionUpdatesSuppressed; // skip selection redraw/scroll (e.g. while hidden behind Quick Look)
 
 @property (class, readonly) NSSize maxCellSize;
 

--- a/DYWrappingMatrix.m
+++ b/DYWrappingMatrix.m
@@ -115,6 +115,12 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 	BOOL _respondsToLoadImageForFile, _respondsToSelectionDidChange;
 	NSMutableArray *_movedUrls, *_originPaths;
 	id __weak _appDelegate;
+
+	// instant hover tool tip for truncated file names
+	NSTrackingArea *_nameTipTracking;
+	NSWindow *_nameTipWindow;
+	NSTextField *_nameTipField;
+	NSInteger _nameTipIndex; // cell the tip is currently showing, or -1
 }
 @synthesize delegate, loadingImage;
 
@@ -174,7 +180,8 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 		_maxCellWidth = FLT_MAX;
 		textHeight = round(DEFAULT_TEXTHEIGHT * DYInterfaceTextScale());
 		autoRotate = YES;
-		
+		_nameTipIndex = -1;
+
 		[self registerForDraggedTypes:@[NSPasteboardTypeFileURL]];
 	}
 	return self;
@@ -579,11 +586,107 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 		_contentSize = mySize;
 		[self invalidateIntrinsicContentSize];
 	}
+	[self hideNameTip]; // a reflow would leave any visible name tip over the wrong cell
 }
 
 - (NSSize)intrinsicContentSize
 {
 	return _contentSize;
+}
+
+- (NSFont *)labelFont {
+	// base size ranges 6 to 12 with the thumbnail size, scaled by the interface text size
+	return [NSFont systemFontOfSize:(cellWidth >= 160 ? 12 : 4+cellWidth/20) * DYInterfaceTextScale()];
+}
+
+#pragma mark instant name tool tips
+// Reveal the full file name on hover, but only when it isn't already fully
+// visible: either the labels are hidden, or the name is too long for its cell
+// and would be drawn truncated with an ellipsis. We draw the tip ourselves in a
+// small borderless window so it appears instantly, without the system tool-tip
+// hover delay (which AppKit re-arms every time the pointer enters a new cell).
+- (BOOL)nameIsClippedAtIndex:(NSUInteger)i {
+	if (textHeight == 0) return YES; // labels hidden: nothing is shown, so reveal it
+	NSString *name = [filenames[i] lastPathComponent];
+	CGFloat textWidth = [name sizeWithAttributes:@{NSFontAttributeName: self.labelFont}].width;
+	return ceil(textWidth) > area_w - 4; // account for the cell's ~2px inset on each side
+}
+
+- (void)updateTrackingAreas {
+	[super updateTrackingAreas];
+	if (_nameTipTracking) [self removeTrackingArea:_nameTipTracking];
+	_nameTipTracking = [[NSTrackingArea alloc] initWithRect:NSZeroRect
+		options:NSTrackingMouseMoved|NSTrackingMouseEnteredAndExited|NSTrackingActiveInKeyWindow|NSTrackingInVisibleRect
+		owner:self userInfo:nil];
+	[self addTrackingArea:_nameTipTracking];
+}
+
+- (void)mouseMoved:(NSEvent *)e {
+	[super mouseMoved:e];
+	NSPoint p = [self convertPoint:e.locationInWindow fromView:nil];
+	NSInteger i = [self point2cellnum:p];
+	if (i < 0 || i >= (NSInteger)numCells || !NSPointInRect(p, [self cellnum2rect:i]) || ![self nameIsClippedAtIndex:i])
+		[self hideNameTip];
+	else
+		[self showNameTip:[filenames[i] lastPathComponent] forCell:i];
+}
+
+- (void)mouseExited:(NSEvent *)e {
+	[super mouseExited:e];
+	[self hideNameTip];
+}
+
+- (void)scrollWheel:(NSEvent *)e {
+	[self hideNameTip]; // don't leave a stale tip while the content scrolls under the cursor
+	[super scrollWheel:e];
+}
+
+- (void)hideNameTip {
+	_nameTipIndex = -1;
+	[_nameTipWindow orderOut:nil];
+}
+
+- (void)showNameTip:(NSString *)name forCell:(NSInteger)i {
+	if (_nameTipWindow.isVisible && _nameTipIndex == i) return; // already showing this cell
+	_nameTipIndex = i;
+	if (!_nameTipWindow) {
+		NSView *bg = [[NSView alloc] initWithFrame:NSZeroRect];
+		bg.wantsLayer = YES;
+		bg.layer.cornerRadius = 4;
+		bg.layer.borderWidth = 0.5;
+		_nameTipField = [NSTextField labelWithString:@""];
+		_nameTipField.font = [NSFont toolTipsFontOfSize:0];
+		[bg addSubview:_nameTipField];
+		_nameTipWindow = [[NSWindow alloc] initWithContentRect:NSZeroRect styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:NO];
+		_nameTipWindow.opaque = NO;
+		_nameTipWindow.backgroundColor = NSColor.clearColor;
+		_nameTipWindow.hasShadow = YES;
+		_nameTipWindow.level = NSPopUpMenuWindowLevel;
+		_nameTipWindow.ignoresMouseEvents = YES;
+		_nameTipWindow.contentView = bg;
+	}
+	// match the current appearance, then lay out around the text
+	_nameTipWindow.appearance = self.window.effectiveAppearance;
+	NSView *bg = _nameTipWindow.contentView;
+	bg.layer.backgroundColor = NSColor.controlBackgroundColor.CGColor;
+	bg.layer.borderColor = [NSColor.gridColor colorWithAlphaComponent:0.8].CGColor;
+	_nameTipField.textColor = NSColor.controlTextColor;
+	_nameTipField.stringValue = name;
+	[_nameTipField sizeToFit];
+	const CGFloat padX = 6, padY = 3;
+	NSSize fs = _nameTipField.frame.size;
+	_nameTipField.frameOrigin = NSMakePoint(padX, padY);
+	NSRect wf = NSMakeRect(0, 0, ceil(fs.width) + padX*2, ceil(fs.height) + padY*2);
+	// place just below-right of the cursor, clamped to the screen
+	NSPoint m = NSEvent.mouseLocation;
+	wf.origin = NSMakePoint(m.x + 12, m.y - wf.size.height - 16);
+	NSRect vis = (self.window.screen ?: NSScreen.mainScreen).visibleFrame;
+	if (NSMaxX(wf) > NSMaxX(vis)) wf.origin.x = NSMaxX(vis) - wf.size.width;
+	if (wf.origin.x < NSMinX(vis)) wf.origin.x = NSMinX(vis);
+	if (wf.origin.y < NSMinY(vis)) wf.origin.y = m.y + 16; // flip above the cursor near the screen's bottom
+	[_nameTipWindow setFrame:wf display:YES];
+	if (!_nameTipWindow.isVisible)
+		[_nameTipWindow orderFront:nil];
 }
 
 - (void)drawRect:(NSRect)rect {
@@ -598,7 +701,7 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 	NSRect textCellRect = NSMakeRect(0, 0, area_w, textHeight + _vPadding/2);
 	NSRect cellRect;
 	NSWindow *myWindow = self.window;
-	myTextCell.font = [NSFont systemFontOfSize:(cellWidth >= 160 ? 12 : 4+cellWidth/20) * DYInterfaceTextScale()]; // base ranges 6 to 12, scaled by the interface text size
+	myTextCell.font = self.labelFont;
 	myTextCell.textColor = bgColor.bestTextColor;
 	for (i=0; i<numCells; ++i) {
 		row = i/numCols;

--- a/DYWrappingMatrix.m
+++ b/DYWrappingMatrix.m
@@ -317,6 +317,15 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 										 cellWidth, cellHeight)); // rect for cell only
 }
 
+// a cell's thumbnail rect in screen coordinates (for the Quick Look zoom
+// animation), or NSZeroRect if the cell is scrolled out of view
+- (NSRect)screenRectForCellAtIndex:(NSUInteger)n {
+	if (n >= numCells) return NSZeroRect;
+	NSRect r = [self imageRectForIndex:n];
+	if (!NSIntersectsRect(r, self.visibleRect)) return NSZeroRect;
+	return [self.window convertRectToScreen:[self convertRect:r toView:nil]];
+}
+
 - (void)selectionNeedsDisplay:(NSUInteger)n {
 	NSUInteger row, col;
 	row = n/numCols;

--- a/DYWrappingMatrix.m
+++ b/DYWrappingMatrix.m
@@ -101,6 +101,8 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 	float cellWidth;
 	NSUInteger numCells;
 	NSMutableIndexSet *selectedIndexes;
+	NSUInteger _selAnchor, _selCursor; // keyboard range-selection pivot and moving end
+	BOOL _keyboardSelValid;            // NO after a mouse/select-all change, so keys re-sync
 	
 	BOOL dragEntered;
 	
@@ -427,6 +429,7 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 #pragma mark event stuff
 - (void)mouseDown:(NSEvent *)theEvent {
 	[self.window makeFirstResponder:self];
+	_keyboardSelValid = NO; // mouse changed the selection; let keyboard re-derive its cursor
 	if (numCells == 0) return;
 	BOOL keepOn = YES;
 	char doDrag = 0;
@@ -822,17 +825,50 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 	[self notifySelectionDidChange];
 }
 
+// Replace the selection with a single cell (plain arrow / Home / End).
+- (void)setSingleSelection:(NSUInteger)n {
+	NSMutableIndexSet *dirty = [selectedIndexes mutableCopy];
+	[selectedIndexes removeAllIndexes];
+	[selectedIndexes addIndex:n];
+	[dirty addIndex:n];
+	for (NSUInteger i = dirty.firstIndex; i != NSNotFound; i = [dirty indexGreaterThanIndex:i])
+		[self selectionNeedsDisplay:i];
+	_selAnchor = _selCursor = n;
+	_keyboardSelValid = YES;
+	[self scrollSelectionToVisible:n]; // notifies + scrolls
+}
+
+// Extend the selection from the anchor to n (shift + arrow / Home / End).
+- (void)extendSelectionTo:(NSUInteger)n {
+	NSUInteger anchor = (_keyboardSelValid && _selAnchor < numCells) ? _selAnchor
+		: (selectedIndexes.count ? selectedIndexes.firstIndex : n);
+	NSMutableIndexSet *dirty = [selectedIndexes mutableCopy];
+	[selectedIndexes removeAllIndexes];
+	NSUInteger lo = MIN(anchor, n), hi = MAX(anchor, n);
+	[selectedIndexes addIndexesInRange:NSMakeRange(lo, hi - lo + 1)];
+	[dirty addIndexes:selectedIndexes];
+	for (NSUInteger i = dirty.firstIndex; i != NSNotFound; i = [dirty indexGreaterThanIndex:i])
+		[self selectionNeedsDisplay:i];
+	_selAnchor = anchor;
+	_selCursor = n;
+	_keyboardSelValid = YES;
+	[self scrollSelectionToVisible:n];
+}
+
 - (void)keyDown:(NSEvent *)e {
 	if (e.characters.length == 0) return;
 	unichar c = [e.characters characterAtIndex:0];
+	BOOL shift = (e.modifierFlags & NSEventModifierFlagShift) != 0;
 	NSRect r;
 	switch (c) {
 		case NSHomeFunctionKey:
+			if (shift && numCells) { [self extendSelectionTo:0]; return; }
 			r = [self cellnum2rect:0];
 			r.size.height = (int)r.size.height;
 			[self scrollRectToVisible:r];
 			return;
 		case NSEndFunctionKey:
+			if (shift && numCells) { [self extendSelectionTo:numCells-1]; return; }
 			r = [self cellnum2rect:filenames.count-1];
 			r.size.height = (int)r.size.height;
 			[self scrollRectToVisible:r];
@@ -851,40 +887,26 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 				[super keyDown:e];
 			return;
 	}
+	if (numCells == 0) return;
+	BOOL forward = (c == NSRightArrowFunctionKey || c == NSDownArrowFunctionKey);
+	// the moving end: the keyboard cursor, falling back to the current selection edge
+	NSUInteger base = (_keyboardSelValid && _selCursor < numCells) ? _selCursor
+		: (selectedIndexes.count ? (forward ? selectedIndexes.lastIndex : selectedIndexes.firstIndex) : NSNotFound);
 	NSUInteger n;
-	if (selectedIndexes.count == 1) {
-		n = selectedIndexes.firstIndex;
-		[self selectionNeedsDisplay:n];
+	if (base == NSNotFound) {
+		n = forward ? 0 : numCells - 1; // empty selection: enter at the near edge, no move
+	} else {
+		n = base;
 		switch (c) {
-			case NSRightArrowFunctionKey: if (n<numCells-1) n++; break;
-			case NSLeftArrowFunctionKey:  if (n>0) n--; break;
-			case NSDownArrowFunctionKey:
-				if ((numCells - 1 - n) < numCols) n = numCells-1;
-				else n += numCols;
-				break;
-			case NSUpArrowFunctionKey:
-				if (numCols > n) n = 0;
-				else n -= numCols;
-				break;
+			case NSRightArrowFunctionKey: if (n < numCells-1) n++; break;
+			case NSLeftArrowFunctionKey:  if (n > 0) n--; break;
+			case NSDownArrowFunctionKey:  n = (numCells - 1 - n) < numCols ? numCells-1 : n + numCols; break;
+			case NSUpArrowFunctionKey:    n = numCols > n ? 0 : n - numCols; break;
 			default: break;
 		}
-		[selectedIndexes removeAllIndexes];
-	} else if (selectedIndexes.count == 0 && numCells > 0) {
-		switch (c) {
-			case NSRightArrowFunctionKey:
-			case NSDownArrowFunctionKey:
-				n = 0;
-				break;
-			case NSLeftArrowFunctionKey:
-			case NSUpArrowFunctionKey:
-			default: // keep the compiler happy about n
-				n = numCells-1;
-				break;
-		}
-	} else
-		return;
-	[selectedIndexes addIndex:n];
-	[self scrollSelectionToVisible:n];
+	}
+	if (shift && base != NSNotFound) [self extendSelectionTo:n];
+	else [self setSingleSelection:n];
 }
 
 - (void)selectIndex:(NSUInteger)i {
@@ -961,6 +983,7 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 	for (i=0; i<numCells; ++i) {
 		[self selectionNeedsDisplay:i];
 	}
+	_keyboardSelValid = NO;
 	[self notifySelectionDidChange];
 }
 

--- a/DYWrappingMatrix.m
+++ b/DYWrappingMatrix.m
@@ -317,15 +317,6 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 										 cellWidth, cellHeight)); // rect for cell only
 }
 
-// a cell's thumbnail rect in screen coordinates (for the Quick Look zoom
-// animation), or NSZeroRect if the cell is scrolled out of view
-- (NSRect)screenRectForCellAtIndex:(NSUInteger)n {
-	if (n >= numCells) return NSZeroRect;
-	NSRect r = [self imageRectForIndex:n];
-	if (!NSIntersectsRect(r, self.visibleRect)) return NSZeroRect;
-	return [self.window convertRectToScreen:[self convertRect:r toView:nil]];
-}
-
 - (void)selectionNeedsDisplay:(NSUInteger)n {
 	NSUInteger row, col;
 	row = n/numCols;

--- a/DYWrappingMatrix.m
+++ b/DYWrappingMatrix.m
@@ -950,7 +950,9 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 }
 
 - (NSString *)firstSelectedFilename {
-	return filenames[selectedIndexes.firstIndex];
+	NSUInteger i = selectedIndexes.firstIndex;
+	// selection can momentarily be empty or stale relative to filenames (e.g. mid-reload)
+	return i < filenames.count ? filenames[i] : nil;
 }
 
 - (IBAction)selectAll:(id)sender {

--- a/DYWrappingMatrix.m
+++ b/DYWrappingMatrix.m
@@ -608,18 +608,9 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 }
 
 #pragma mark instant name tool tips
-// Reveal the full file name on hover, but only when it isn't already fully
-// visible: either the labels are hidden, or the name is too long for its cell
-// and would be drawn truncated with an ellipsis. We draw the tip ourselves in a
-// small borderless window so it appears instantly, without the system tool-tip
-// hover delay (which AppKit re-arms every time the pointer enters a new cell).
-- (BOOL)nameIsClippedAtIndex:(NSUInteger)i {
-	if (textHeight == 0) return YES; // labels hidden: nothing is shown, so reveal it
-	NSString *name = [filenames[i] lastPathComponent];
-	CGFloat textWidth = [name sizeWithAttributes:@{NSFontAttributeName: self.labelFont}].width;
-	return ceil(textWidth) > area_w - 4; // account for the cell's ~2px inset on each side
-}
-
+// Reveal the full file name on hover for every thumbnail. We draw the tip
+// ourselves in a small borderless window so it appears instantly, without the
+// system tool-tip hover delay (which AppKit re-arms on entering each new cell).
 - (void)updateTrackingAreas {
 	[super updateTrackingAreas];
 	if (_nameTipTracking) [self removeTrackingArea:_nameTipTracking];
@@ -633,7 +624,7 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 	[super mouseMoved:e];
 	NSPoint p = [self convertPoint:e.locationInWindow fromView:nil];
 	NSInteger i = [self point2cellnum:p];
-	if (i < 0 || i >= (NSInteger)numCells || !NSPointInRect(p, [self cellnum2rect:i]) || ![self nameIsClippedAtIndex:i])
+	if (i < 0 || i >= (NSInteger)numCells || !NSPointInRect(p, [self cellnum2rect:i]))
 		[self hideNameTip];
 	else
 		[self showNameTip:[filenames[i] lastPathComponent] forCell:i];
@@ -685,13 +676,18 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 	NSSize fs = _nameTipField.frame.size;
 	_nameTipField.frameOrigin = NSMakePoint(padX, padY);
 	NSRect wf = NSMakeRect(0, 0, ceil(fs.width) + padX*2, ceil(fs.height) + padY*2);
-	// place just below-right of the cursor, clamped to the screen
-	NSPoint m = NSEvent.mouseLocation;
-	wf.origin = NSMakePoint(m.x + 12, m.y - wf.size.height - 16);
+	// anchor over the hovered cell's file-name label, centered on the cell, so the
+	// popup reads as the truncated label expanded in place
+	NSUInteger row = i / numCols, col = i % numCols;
+	CGFloat stripH = (textHeight ? textHeight : 12) + _vPadding/2;
+	NSRect label = NSMakeRect(area_w*col, area_h*row + area_h - stripH, area_w, stripH);
+	label = [self.window convertRectToScreen:[self convertRect:label toView:nil]];
+	wf.origin.x = round(NSMidX(label) - wf.size.width/2);
+	wf.origin.y = round(NSMidY(label) - wf.size.height/2); // sit directly over the label
 	NSRect vis = (self.window.screen ?: NSScreen.mainScreen).visibleFrame;
 	if (NSMaxX(wf) > NSMaxX(vis)) wf.origin.x = NSMaxX(vis) - wf.size.width;
 	if (wf.origin.x < NSMinX(vis)) wf.origin.x = NSMinX(vis);
-	if (wf.origin.y < NSMinY(vis)) wf.origin.y = m.y + 16; // flip above the cursor near the screen's bottom
+	if (NSMaxY(wf) > NSMaxY(vis)) wf.origin.y = NSMaxY(vis) - wf.size.height; // keep on-screen at the top
 	[_nameTipWindow setFrame:wf display:YES];
 	if (!_nameTipWindow.isVisible)
 		[_nameTipWindow orderFront:nil];

--- a/DYWrappingMatrix.m
+++ b/DYWrappingMatrix.m
@@ -845,7 +845,12 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 		case NSUpArrowFunctionKey:
 			break;
 		default:
-			[super keyDown:e];
+			// Let menu shortcuts fire before NSControl turns Space/Return into a
+			// click on our action (which starts the slideshow). This is what makes
+			// Space = Quick Look while Return still begins the slideshow. AppKit does
+			// not auto-dispatch no-modifier menu key equivalents (like plain Space).
+			if (![NSApp.mainMenu performKeyEquivalent:e])
+				[super keyDown:e];
 			return;
 	}
 	NSUInteger n;

--- a/DYWrappingMatrix.m
+++ b/DYWrappingMatrix.m
@@ -12,6 +12,8 @@
 #import "NSMutableArray+DYMovable.h"
 #import "NSColor+TextColor.h"
 
+CGFloat DYInterfaceTextScale(void); // defined in CreeveyController.m
+
 #define MAX_EXIF_WIDTH  160
 #define MIN_CELL_WIDTH  40
 #define PADDING 16
@@ -170,7 +172,7 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 		_originPaths = [[NSMutableArray alloc] init];
 		// cellWidth should be initialized by an external controller during awakeFromNib
 		_maxCellWidth = FLT_MAX;
-		textHeight = DEFAULT_TEXTHEIGHT;
+		textHeight = round(DEFAULT_TEXTHEIGHT * DYInterfaceTextScale());
 		autoRotate = YES;
 		
 		[self registerForDraggedTypes:@[NSPasteboardTypeFileURL]];
@@ -373,7 +375,7 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 
 	// show/hide filenames
 	if (b) {
-		textHeight = DEFAULT_TEXTHEIGHT;
+		textHeight = round(DEFAULT_TEXTHEIGHT * DYInterfaceTextScale());
 	} else {
 		textHeight = 0;
 	}
@@ -553,6 +555,12 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 	}
 }
 
+- (void)reloadTextSize {
+	textHeight = round(DEFAULT_TEXTHEIGHT * DYInterfaceTextScale());
+	[self resize:nil];
+	[self setNeedsDisplay:YES];
+}
+
 - (void)resize:(id)anObject {
 	NSRect myFrame = self.frame;
 	if (anObject) {
@@ -590,7 +598,7 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 	NSRect textCellRect = NSMakeRect(0, 0, area_w, textHeight + _vPadding/2);
 	NSRect cellRect;
 	NSWindow *myWindow = self.window;
-	myTextCell.font = [NSFont systemFontOfSize:cellWidth >= 160 ? 12 : 4+cellWidth/20]; // ranges from 6 to 12: 6 + 6*(cellWidth-40)/(160-40)
+	myTextCell.font = [NSFont systemFontOfSize:(cellWidth >= 160 ? 12 : 4+cellWidth/20) * DYInterfaceTextScale()]; // base ranges 6 to 12, scaled by the interface text size
 	myTextCell.textColor = bgColor.bestTextColor;
 	for (i=0; i<numCells; ++i) {
 		row = i/numCols;

--- a/DYWrappingMatrix.m
+++ b/DYWrappingMatrix.m
@@ -221,13 +221,21 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 }
 
 - (void)setMaxCellWidth:(float)w {
-	if (w < _maxCellWidth) {
-		_maxCellWidth = w; // this has to be set before we do the resizing
-		self.cellWidth = cellWidth < w ? cellWidth : w;
+	float oldMax = _maxCellWidth;
+	_maxCellWidth = w; // has to be set before we resize the cells
+	// Keep the size slider at the same fraction of its range, so a size you
+	// deliberately chose scales with the cap instead of snapping to it. When the
+	// slider was already at the maximum this still lands on the new cap.
+	if (oldMax > MIN_CELL_WIDTH && oldMax < FLT_MAX) {
+		float fraction = (cellWidth - MIN_CELL_WIDTH) / (oldMax - MIN_CELL_WIDTH);
+		self.cellWidth = MIN_CELL_WIDTH + fraction * (w - MIN_CELL_WIDTH);
 	} else {
-		_maxCellWidth = w;
-		// tell delegate to reload anything we've loaded already
-		// the delay is to wait for all the other windows to have emptied the thumbs cache before we start repopulating it
+		self.cellWidth = cellWidth < w ? cellWidth : w; // first pass: just clamp into range
+	}
+	if (w > oldMax) {
+		// Raising the cap: reload anything we've already loaded at the higher
+		// resolution. The delay is to wait for all the other windows to have
+		// emptied the thumbs cache before we start repopulating it.
 		NSUInteger n = filenames.count;
 		if (n && _respondsToLoadImageForFile) dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
 			for (NSUInteger i = 0; i < n; ++i) {

--- a/DYWrappingMatrix.m
+++ b/DYWrappingMatrix.m
@@ -318,6 +318,7 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 }
 
 - (void)selectionNeedsDisplay:(NSUInteger)n {
+	if (_selectionUpdatesSuppressed) return; // grid is hidden (Quick Look); redraw happens on restore
 	NSUInteger row, col;
 	row = n/numCols;
 	col = n%numCols;
@@ -797,6 +798,7 @@ static NSRect ScaledCenteredRect(NSSize sourceSize, NSRect boundsRect) {
 }
 - (void)scrollSelectionToVisible:(NSUInteger)n {
 	[self notifySelectionDidChange];
+	if (_selectionUpdatesSuppressed) return; // don't scroll/redraw a grid hidden behind Quick Look
 	NSRect r = [self cellnum2rect:n];
 	[self selectionNeedsDisplay:n];
 	// round down for better auto-scrolling

--- a/KeyBindings.h
+++ b/KeyBindings.h
@@ -1,0 +1,71 @@
+//Copyright 2005-2023 Dominic Yu. Some rights reserved.
+//This work is licensed under the Creative Commons
+//Attribution-NonCommercial-ShareAlike License. To view a copy of this
+//license, visit http://creativecommons.org/licenses/by-nc-sa/2.0/ or send
+//a letter to Creative Commons, 559 Nathan Abbott Way, Stanford,
+//California 94305, USA.
+
+// KeyBindings reads a user-editable JSON file (~/Library/Application Support/
+// Phoenix Slides/config.json) that reassigns keyboard shortcuts. It is loaded at
+// launch and can be reloaded live. Scope is keybindings only; it does not touch
+// NSUserDefaults settings.
+
+@import Cocoa;
+
+// Rebindable single-key actions handled in SlideshowWindow keyDown:.
+// Navigation keys (arrows, space, digits, esc, F-keys, …) are NOT rebindable and
+// are intentionally absent here.
+typedef NS_ENUM(NSInteger, SlideshowAction) {
+	SlideshowActionNone = 0,
+	SlideshowActionRotateLeft,
+	SlideshowActionRotateRight,
+	SlideshowActionFlip,
+	SlideshowActionRename,
+	SlideshowActionMoveToTrash,
+	SlideshowActionDeletePermanently,
+	SlideshowActionToggleInfo,
+	SlideshowActionTogglePath,
+	SlideshowActionMoreExif,
+	SlideshowActionHelp,
+	SlideshowActionZoomIn,
+	SlideshowActionZoomOut,
+	SlideshowActionActualSize,
+	SlideshowActionResetView,
+};
+
+// Rebindable single-key actions handled in the browser (CreeveyMainWindowController).
+typedef NS_ENUM(NSInteger, BrowserAction) {
+	BrowserActionNone = 0,
+	BrowserActionMoveToTrash,
+	BrowserActionDeletePermanently,
+	BrowserActionRename,
+};
+
+@interface KeyBindings : NSObject
+
+// ~/Library/Application Support/Phoenix Slides/config.json
+@property (nonatomic, readonly) NSURL *fileURL;
+
+// Read the file (validating against the action catalog) and build the binding
+// maps. Missing file / bad entries fall back to built-in defaults. Safe to call
+// repeatedly (this is what "Reload Configuration" does).
+- (void)load;
+
+// Apply the current menu-shortcut bindings to the app's main menu.
+- (void)applyToMainMenu;
+
+// Dispatch lookups for the refactored keyDown: handlers.
+- (SlideshowAction)slideshowActionForEvent:(NSEvent *)e;
+- (BrowserAction)browserActionForEvent:(NSEvent *)e;
+
+// Show a single summarizing alert if the last load produced validation errors.
+- (void)reportErrorsIfAny;
+
+// Write the commented default template if the file doesn't exist yet.
+- (void)writeTemplateIfMissing;
+
+// Menu command helpers.
+- (void)openInEditor;    // writes the template if missing, then opens the file
+- (void)revealInFinder;  // selects the file in the Finder
+
+@end

--- a/KeyBindings.h
+++ b/KeyBindings.h
@@ -31,6 +31,10 @@ typedef NS_ENUM(NSInteger, SlideshowAction) {
 	SlideshowActionZoomOut,
 	SlideshowActionActualSize,
 	SlideshowActionResetView,
+	SlideshowActionScrollUp,
+	SlideshowActionScrollDown,
+	SlideshowActionScrollLeft,
+	SlideshowActionScrollRight,
 };
 
 // Rebindable single-key actions handled in the browser (CreeveyMainWindowController).

--- a/KeyBindings.m
+++ b/KeyBindings.m
@@ -43,6 +43,7 @@ static const DYMenuActionDef kMenuActions[] = {
 	{"menu.sortByFilePath",   207},
 	{"menu.showDirectoryBrowser", 25},  // tag added in MainMenu.xib
 	{"menu.showPathBar",       26},  // tag added in MainMenu.xib
+	{"menu.showUnsupportedFiles", 27},  // tag added in MainMenu.xib
 	{"menu.saveRotation",     117},
 	{"menu.advancedOptions",  100},
 	{"menu.toggleLoop",         3},

--- a/KeyBindings.m
+++ b/KeyBindings.m
@@ -17,6 +17,7 @@ typedef struct { const char *actionId; NSInteger tag; } DYMenuActionDef;
 static const DYMenuActionDef kMenuActions[] = {
 	{"menu.newWindow",         18},  // tag added in MainMenu.xib
 	{"menu.newTab",            10},
+	{"menu.goToFolder",        24},  // tag added in MainMenu.xib
 	{"menu.quickLook",         20},  // tag added in MainMenu.xib
 	{"menu.beginSlideshow",     4},
 	{"menu.beginSlideshowInWindow", 11},

--- a/KeyBindings.m
+++ b/KeyBindings.m
@@ -17,6 +17,9 @@ typedef struct { const char *actionId; NSInteger tag; } DYMenuActionDef;
 static const DYMenuActionDef kMenuActions[] = {
 	{"menu.newWindow",         18},  // tag added in MainMenu.xib
 	{"menu.newTab",            10},
+	{"menu.quickLook",         20},  // tag added in MainMenu.xib
+	{"menu.beginSlideshow",     4},
+	{"menu.beginSlideshowInWindow", 11},
 	{"menu.getInfo",            6},
 	{"menu.setDesktop",         5},
 	{"menu.revealInFinder",     1},

--- a/KeyBindings.m
+++ b/KeyBindings.m
@@ -39,6 +39,16 @@ static const DYMenuActionDef kMenuActions[] = {
 	{"menu.sortByDateAdded",  204},
 	{"menu.sortByType",       205},
 	{"menu.sortBySize",       206},
+	{"menu.sortByFilePath",   207},
+	{"menu.saveRotation",     117},
+	{"menu.advancedOptions",  100},
+	{"menu.toggleLoop",         3},
+	{"menu.toggleRandom",       7},
+	{"menu.scaleUp",            8},
+	{"menu.actualSize",         9},
+	{"menu.endSlideshow",      22},  // tag added in MainMenu.xib
+	{"menu.showCheatSheet",    23},  // tag added in MainMenu.xib
+	{"menu.preferences",       21},  // tag added in MainMenu.xib
 };
 
 // Single-key actions. defaultKeys is a comma-separated list of keystrokes; the

--- a/KeyBindings.m
+++ b/KeyBindings.m
@@ -45,6 +45,8 @@ static const DYMenuActionDef kMenuActions[] = {
 	{"menu.showPathBar",       26},  // tag added in MainMenu.xib
 	{"menu.showUnsupportedFiles", 27},  // tag added in MainMenu.xib
 	{"menu.copyAsPathname",    28},  // tag added in MainMenu.xib
+	{"menu.search",            29},  // tag added in MainMenu.xib
+	{"menu.subfolders",        30},  // tag added in MainMenu.xib
 	{"menu.saveRotation",     117},
 	{"menu.advancedOptions",  100},
 	{"menu.toggleLoop",         3},

--- a/KeyBindings.m
+++ b/KeyBindings.m
@@ -47,6 +47,10 @@ static const DYMenuActionDef kMenuActions[] = {
 	{"menu.copyAsPathname",    28},  // tag added in MainMenu.xib
 	{"menu.search",            29},  // tag added in MainMenu.xib
 	{"menu.subfolders",        30},  // tag added in MainMenu.xib
+	{"menu.zoomIn",            31},  // tag added in MainMenu.xib
+	{"menu.zoomOut",           32},  // tag added in MainMenu.xib
+	{"menu.zoomActualSize",    33},  // tag added in MainMenu.xib
+	{"menu.zoomFitToWindow",   34},  // tag added in MainMenu.xib
 	{"menu.saveRotation",     117},
 	{"menu.advancedOptions",  100},
 	{"menu.toggleLoop",         3},
@@ -77,6 +81,10 @@ static const DYKeyActionDef kSlideshowActions[] = {
 	{"slideshow.zoomOut",            SlideshowActionZoomOut,            "-"},
 	{"slideshow.actualSize",         SlideshowActionActualSize,         "="},
 	{"slideshow.resetView",          SlideshowActionResetView,          "*"},
+	{"slideshow.scrollUp",           SlideshowActionScrollUp,           "shift+up"},
+	{"slideshow.scrollDown",         SlideshowActionScrollDown,         "shift+down"},
+	{"slideshow.scrollLeft",         SlideshowActionScrollLeft,         "shift+left"},
+	{"slideshow.scrollRight",        SlideshowActionScrollRight,        "shift+right"},
 };
 
 static const DYKeyActionDef kBrowserActions[] = {
@@ -174,14 +182,26 @@ static BOOL ParseKeystroke(NSString *s, NSString **outKey, NSEventModifierFlags 
 	return YES;
 }
 
-// The character e.characters would produce for a modifier-free viewer keystroke,
-// or nil if the keystroke isn't valid as a single-key viewer binding.
-static NSString *ViewerCharForKeystroke(NSString *s) {
-	NSString *key; NSEventModifierFlags mask;
-	if (!ParseKeystroke(s, &key, &mask)) return nil;
-	if (mask != 0) return nil; // viewer keys carry no cmd/ctrl/opt (shift is folded into the char)
-	if (key.length != 1) return nil;
-	return key;
+// Viewer bindings are matched by a normalized "modifier-mask|key" token, so a keystroke
+// like ⇧← is distinct from ← (which stays reserved for navigation).
+static const NSEventModifierFlags kViewerMask =
+	NSEventModifierFlagCommand|NSEventModifierFlagControl|NSEventModifierFlagOption|NSEventModifierFlagShift;
+
+static NSString *EncodeViewerKey(NSString *keyEquiv, NSEventModifierFlags mask) {
+	return [NSString stringWithFormat:@"%lu|%@", (unsigned long)(mask & kViewerMask), keyEquiv];
+}
+
+// Token for a key event. For printable keys shift is already folded into the character
+// (charactersIgnoringModifiers keeps shift, so "+" and "D" arrive as-is) and dropped from the
+// mask; for function keys (arrows, etc.) shift is kept, so ⇧← ≠ ←.
+static NSString *EncodeViewerEvent(NSEvent *e) {
+	NSString *chars = e.charactersIgnoringModifiers.length ? e.charactersIgnoringModifiers : e.characters;
+	if (chars.length == 0) return nil;
+	NSEventModifierFlags mask = e.modifierFlags & kViewerMask;
+	unichar c = [chars characterAtIndex:0];
+	BOOL functionKey = (c >= 0xF700 && c <= 0xF8FF); // NSUpArrowFunctionKey … et al.
+	if (!functionKey) mask &= ~NSEventModifierFlagShift; // shift is folded into the printable char
+	return EncodeViewerKey(chars, mask);
 }
 
 #pragma mark -
@@ -325,20 +345,23 @@ static NSString *ViewerCharForKeystroke(NSString *s) {
 			keystrokes = @[];
 		}
 		for (NSString *ks in keystrokes) {
-			NSString *ch = ViewerCharForKeystroke(ks);
-			if (!ch) {
+			NSString *key; NSEventModifierFlags mask;
+			if (!ParseKeystroke(ks, &key, &mask) || key.length != 1) {
 				[_errors addObject:[NSString stringWithFormat:@"\"%@\" is not a valid single-key shortcut for \"%@\".", ks, actionId]];
 				continue;
 			}
-			if ([ReservedViewerChars() characterIsMember:[ch characterAtIndex:0]]) {
+			// plain (unmodified) navigation keys stay reserved; the same key with a modifier
+			// (e.g. ⇧←) is fair game
+			if (mask == 0 && [ReservedViewerChars() characterIsMember:[key characterAtIndex:0]]) {
 				[_errors addObject:[NSString stringWithFormat:@"\"%@\" is reserved for navigation and can't be reassigned (\"%@\").", ks, actionId]];
 				continue;
 			}
-			if (dispatch[ch]) {
-				[_errors addObject:[NSString stringWithFormat:@"The key \"%@\" is bound to more than one action; keeping the first.", ch]];
+			NSString *tok = EncodeViewerKey(key, mask);
+			if (dispatch[tok]) {
+				[_errors addObject:[NSString stringWithFormat:@"The key \"%@\" is bound to more than one action; keeping the first.", ks]];
 				continue; // first occurrence wins
 			}
-			dispatch[ch] = code;
+			dispatch[tok] = code;
 		}
 	}
 }
@@ -403,16 +426,16 @@ static NSMenuItem *MenuItemWithTag(NSMenu *menu, NSInteger tag) {
 #pragma mark Dispatch
 
 - (SlideshowAction)slideshowActionForEvent:(NSEvent *)e {
-	NSString *chars = e.characters;
-	if (chars.length == 0) return SlideshowActionNone;
-	NSNumber *code = _slideshowDispatch[chars];
+	NSString *tok = EncodeViewerEvent(e);
+	if (!tok) return SlideshowActionNone;
+	NSNumber *code = _slideshowDispatch[tok];
 	return code ? (SlideshowAction)code.integerValue : SlideshowActionNone;
 }
 
 - (BrowserAction)browserActionForEvent:(NSEvent *)e {
-	NSString *chars = e.characters;
-	if (chars.length == 0) return BrowserActionNone;
-	NSNumber *code = _browserDispatch[chars];
+	NSString *tok = EncodeViewerEvent(e);
+	if (!tok) return BrowserActionNone;
+	NSNumber *code = _browserDispatch[tok];
 	return code ? (BrowserAction)code.integerValue : BrowserActionNone;
 }
 
@@ -471,7 +494,8 @@ static NSMenuItem *MenuItemWithTag(NSMenu *menu, NSInteger tag) {
 		"  //\n"
 		"  // Value: a keystroke string, a list of strings, or null for no shortcut.\n"
 		"  // Modifiers: cmd, ctrl, opt, shift. Examples: \"cmd+shift+i\", \"n\", \"D\".\n"
-		"  // Single-key (slideshow/browser) shortcuts take no cmd/ctrl/opt.\n"
+		"  // Slideshow/browser keys may use modifiers too, e.g. \"shift+left\" to pan;\n"
+		"  // vim users can set slideshow.scrollLeft/Right/Up/Down to \"h\"/\"l\"/\"k\"/\"j\".\n"
 		"  // Delete a line to fall back to the built-in default.\n"
 		"  \"keybindings\": {\n"];
 	NSString *lastSection = nil;

--- a/KeyBindings.m
+++ b/KeyBindings.m
@@ -44,6 +44,7 @@ static const DYMenuActionDef kMenuActions[] = {
 	{"menu.showDirectoryBrowser", 25},  // tag added in MainMenu.xib
 	{"menu.showPathBar",       26},  // tag added in MainMenu.xib
 	{"menu.showUnsupportedFiles", 27},  // tag added in MainMenu.xib
+	{"menu.copyAsPathname",    28},  // tag added in MainMenu.xib
 	{"menu.saveRotation",     117},
 	{"menu.advancedOptions",  100},
 	{"menu.toggleLoop",         3},

--- a/KeyBindings.m
+++ b/KeyBindings.m
@@ -1,0 +1,513 @@
+//Copyright 2005-2023 Dominic Yu. Some rights reserved.
+//This work is licensed under the Creative Commons
+//Attribution-NonCommercial-ShareAlike License. To view a copy of this
+//license, visit http://creativecommons.org/licenses/by-nc-sa/2.0/ or send
+//a letter to Creative Commons, 559 Nathan Abbott Way, Stanford,
+//California 94305, USA.
+
+#import "KeyBindings.h"
+
+#pragma mark Action catalog
+
+// Menu commands are identified by their existing NSMenuItem tag (see the anonymous
+// enum in CreeveyController.m). We only ever change an item the config file names,
+// so these tags are the single coupling point; defaults come from the .xib.
+typedef struct { const char *actionId; NSInteger tag; } DYMenuActionDef;
+
+static const DYMenuActionDef kMenuActions[] = {
+	{"menu.newWindow",         18},  // tag added in MainMenu.xib
+	{"menu.newTab",            10},
+	{"menu.getInfo",            6},
+	{"menu.setDesktop",         5},
+	{"menu.revealInFinder",     1},
+	{"menu.moveTo",            12},
+	{"menu.moveToAgain",       13},
+	{"menu.copyTo",            14},
+	{"menu.copyToAgain",       15},
+	{"menu.moveToTrash",        2},
+	{"menu.rename",            16},
+	{"menu.deletePermanently", 17},
+	{"menu.selectNone",        19},  // tag added in MainMenu.xib
+	{"menu.rotateRightSave",  105},
+	{"menu.rotateLeftSave",   107},
+	{"menu.sortByName",       201},
+	{"menu.sortByModified",   202},
+	{"menu.sortByExifDate",   203},
+	{"menu.sortByDateAdded",  204},
+	{"menu.sortByType",       205},
+	{"menu.sortBySize",       206},
+};
+
+// Single-key actions. defaultKeys is a comma-separated list of keystrokes; the
+// catalog is the source of truth for the built-in keys (moved out of keyDown:).
+typedef struct { const char *actionId; NSInteger code; const char *defaultKeys; } DYKeyActionDef;
+
+static const DYKeyActionDef kSlideshowActions[] = {
+	{"slideshow.rotateLeft",         SlideshowActionRotateLeft,         "l"},
+	{"slideshow.rotateRight",        SlideshowActionRotateRight,        "r"},
+	{"slideshow.flip",               SlideshowActionFlip,               "f"},
+	{"slideshow.rename",             SlideshowActionRename,             "e"},
+	{"slideshow.moveToTrash",        SlideshowActionMoveToTrash,        "d"},
+	{"slideshow.deletePermanently",  SlideshowActionDeletePermanently,  "D"},
+	{"slideshow.toggleInfo",         SlideshowActionToggleInfo,         "i"},
+	{"slideshow.togglePath",         SlideshowActionTogglePath,         "p"},
+	{"slideshow.moreExif",           SlideshowActionMoreExif,           "I"},
+	{"slideshow.help",               SlideshowActionHelp,               "h,?,/"},
+	{"slideshow.zoomIn",             SlideshowActionZoomIn,             "+"},
+	{"slideshow.zoomOut",            SlideshowActionZoomOut,            "-"},
+	{"slideshow.actualSize",         SlideshowActionActualSize,         "="},
+	{"slideshow.resetView",          SlideshowActionResetView,          "*"},
+};
+
+static const DYKeyActionDef kBrowserActions[] = {
+	{"browser.moveToTrash",       BrowserActionMoveToTrash,       "d"},
+	{"browser.deletePermanently", BrowserActionDeletePermanently, "D"},
+	{"browser.rename",            BrowserActionRename,            "e"},
+};
+
+// Characters that drive core navigation and can't be reassigned to an action.
+static NSCharacterSet *ReservedViewerChars(void) {
+	static NSCharacterSet *s;
+	static dispatch_once_t once;
+	dispatch_once(&once, ^{
+		NSMutableCharacterSet *m = [NSMutableCharacterSet characterSetWithCharactersInString:@" q0123456789!@"];
+		unichar reserved[] = {
+			0x1b, // esc
+			NSLeftArrowFunctionKey, NSRightArrowFunctionKey, NSUpArrowFunctionKey, NSDownArrowFunctionKey,
+			NSHomeFunctionKey, NSEndFunctionKey, NSPageUpFunctionKey, NSPageDownFunctionKey, NSHelpFunctionKey,
+			NSF1FunctionKey, NSF2FunctionKey, NSF3FunctionKey, NSF4FunctionKey, NSF5FunctionKey, NSF6FunctionKey,
+			NSF7FunctionKey, NSF8FunctionKey, NSF9FunctionKey, NSF10FunctionKey, NSF11FunctionKey, NSF12FunctionKey,
+		};
+		for (size_t i = 0; i < sizeof(reserved)/sizeof(reserved[0]); ++i)
+			[m addCharactersInRange:NSMakeRange(reserved[i], 1)];
+		s = [m copy];
+	});
+	return s;
+}
+
+#pragma mark Keystroke parsing
+
+// Maps a special-key name to its keyEquivalent unichar. Returns 0 if unknown.
+static unichar SpecialKeyChar(NSString *name) {
+	static NSDictionary<NSString*,NSNumber*> *map;
+	static dispatch_once_t once;
+	dispatch_once(&once, ^{
+		map = @{
+			@"delete": @0x08, @"backspace": @0x08, @"forwarddelete": @0x7f,
+			@"space": @0x20, @"return": @0x0d, @"enter": @0x0d, @"tab": @0x09,
+			@"esc": @0x1b, @"escape": @0x1b,
+			@"left": @(NSLeftArrowFunctionKey), @"right": @(NSRightArrowFunctionKey),
+			@"up": @(NSUpArrowFunctionKey), @"down": @(NSDownArrowFunctionKey),
+			@"home": @(NSHomeFunctionKey), @"end": @(NSEndFunctionKey),
+			@"pageup": @(NSPageUpFunctionKey), @"pagedown": @(NSPageDownFunctionKey),
+			@"f1": @(NSF1FunctionKey), @"f2": @(NSF2FunctionKey), @"f3": @(NSF3FunctionKey),
+			@"f4": @(NSF4FunctionKey), @"f5": @(NSF5FunctionKey), @"f6": @(NSF6FunctionKey),
+			@"f7": @(NSF7FunctionKey), @"f8": @(NSF8FunctionKey), @"f9": @(NSF9FunctionKey),
+			@"f10": @(NSF10FunctionKey), @"f11": @(NSF11FunctionKey), @"f12": @(NSF12FunctionKey),
+		};
+	});
+	NSNumber *n = map[name.lowercaseString];
+	return n ? (unichar)n.unsignedShortValue : 0;
+}
+
+// Parse "cmd+shift+i" style into a menu key equivalent + modifier mask.
+// Returns NO on any malformed component.
+static BOOL ParseKeystroke(NSString *s, NSString **outKey, NSEventModifierFlags *outMask) {
+	if (s.length == 0) return NO;
+	NSString *token;
+	NSEventModifierFlags mask = 0;
+	if (s.length == 1) {
+		token = s; // a lone character, including "+"
+	} else {
+		NSArray<NSString *> *parts = [s componentsSeparatedByString:@"+"];
+		// last non-empty part is the key; the rest are modifiers
+		token = parts.lastObject;
+		for (NSUInteger i = 0; i + 1 < parts.count; ++i) {
+			NSString *m = parts[i].lowercaseString;
+			if (m.length == 0) continue; // e.g. trailing "+"
+			if ([m isEqualToString:@"cmd"] || [m isEqualToString:@"command"]) mask |= NSEventModifierFlagCommand;
+			else if ([m isEqualToString:@"ctrl"] || [m isEqualToString:@"control"]) mask |= NSEventModifierFlagControl;
+			else if ([m isEqualToString:@"opt"] || [m isEqualToString:@"option"] || [m isEqualToString:@"alt"]) mask |= NSEventModifierFlagOption;
+			else if ([m isEqualToString:@"shift"]) mask |= NSEventModifierFlagShift;
+			else return NO; // unknown modifier
+		}
+		if (token.length == 0) token = @"+"; // the key itself was "+"
+	}
+
+	NSString *keyEquiv;
+	if (token.length == 1) {
+		unichar c = [token characterAtIndex:0];
+		if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
+			BOOL shifted = (c >= 'A' && c <= 'Z') || (mask & NSEventModifierFlagShift) != 0;
+			keyEquiv = shifted ? token.uppercaseString : token.lowercaseString;
+			mask &= ~NSEventModifierFlagShift; // an uppercase letter already implies shift
+		} else {
+			keyEquiv = token; // punctuation / digit
+		}
+	} else {
+		unichar c = SpecialKeyChar(token);
+		if (c == 0) return NO; // unknown special key
+		keyEquiv = [NSString stringWithCharacters:&c length:1];
+	}
+	if (outKey) *outKey = keyEquiv;
+	if (outMask) *outMask = mask;
+	return YES;
+}
+
+// The character e.characters would produce for a modifier-free viewer keystroke,
+// or nil if the keystroke isn't valid as a single-key viewer binding.
+static NSString *ViewerCharForKeystroke(NSString *s) {
+	NSString *key; NSEventModifierFlags mask;
+	if (!ParseKeystroke(s, &key, &mask)) return nil;
+	if (mask != 0) return nil; // viewer keys carry no cmd/ctrl/opt (shift is folded into the char)
+	if (key.length != 1) return nil;
+	return key;
+}
+
+#pragma mark -
+
+@implementation KeyBindings {
+	// actionId -> @[keyEquiv, @(mask)] or NSNull (explicit unbind). Only keys the file names.
+	NSMutableDictionary<NSString*, id> *_menuOverrides;
+	// actionId -> @[keyEquiv, @(mask)] captured from the .xib once, to revert to.
+	NSMutableDictionary<NSString*, NSArray*> *_menuDefaults;
+	NSMutableDictionary<NSString*, NSNumber*> *_slideshowDispatch; // char -> SlideshowAction
+	NSMutableDictionary<NSString*, NSNumber*> *_browserDispatch;   // char -> BrowserAction
+	NSMutableArray<NSString*> *_errors;
+}
+
+- (instancetype)init {
+	if (!(self = [super init])) return nil;
+	_menuOverrides = [NSMutableDictionary dictionary];
+	_slideshowDispatch = [NSMutableDictionary dictionary];
+	_browserDispatch = [NSMutableDictionary dictionary];
+	_errors = [NSMutableArray array];
+	return self;
+}
+
+- (NSURL *)fileURL {
+	NSURL *appSupport = [NSFileManager.defaultManager URLForDirectory:NSApplicationSupportDirectory
+															inDomain:NSUserDomainMask appropriateForURL:nil create:NO error:NULL];
+	// .jsonc so editors allow the // comments (JSON-with-comments) without lint errors
+	return [[appSupport URLByAppendingPathComponent:@"Phoenix Slides" isDirectory:YES]
+			URLByAppendingPathComponent:@"keybindings.jsonc" isDirectory:NO];
+}
+
+// the pre-.jsonc filename, migrated forward if present so edits aren't lost
+- (NSURL *)legacyFileURL {
+	return [self.fileURL.URLByDeletingLastPathComponent URLByAppendingPathComponent:@"keybindings.json" isDirectory:NO];
+}
+
+#pragma mark Loading
+
+- (void)load {
+	[_errors removeAllObjects];
+	[_menuOverrides removeAllObjects];
+	[_slideshowDispatch removeAllObjects];
+	[_browserDispatch removeAllObjects];
+
+	// seed viewer dispatch with the built-in defaults; overrides replace per-action below
+	NSMutableDictionary<NSString*, NSNumber*> *slideshowById = [NSMutableDictionary dictionary];
+	NSMutableDictionary<NSString*, NSNumber*> *browserById = [NSMutableDictionary dictionary];
+	NSDictionary *keybindings = [self readKeybindings]; // nil if file missing/unreadable/malformed
+
+	// resolve effective keystrokes for each viewer action (override or default)
+	[self buildViewerDispatch:_slideshowDispatch table:kSlideshowActions count:sizeof(kSlideshowActions)/sizeof(kSlideshowActions[0]) overrides:keybindings idToCode:slideshowById];
+	[self buildViewerDispatch:_browserDispatch table:kBrowserActions count:sizeof(kBrowserActions)/sizeof(kBrowserActions[0]) overrides:keybindings idToCode:browserById];
+
+	// menu overrides (only entries the file names)
+	if (keybindings) {
+		for (size_t i = 0; i < sizeof(kMenuActions)/sizeof(kMenuActions[0]); ++i) {
+			NSString *actionId = @(kMenuActions[i].actionId);
+			id val = keybindings[actionId];
+			if (!val) continue; // not named -> keep the .xib default
+			if (val == NSNull.null) { _menuOverrides[actionId] = NSNull.null; continue; }
+			NSString *ks = [val isKindOfClass:NSString.class] ? val : ([val isKindOfClass:NSArray.class] ? [val firstObject] : nil);
+			NSString *key; NSEventModifierFlags mask;
+			if (ks && ParseKeystroke(ks, &key, &mask))
+				_menuOverrides[actionId] = @[key, @(mask)];
+			else
+				[_errors addObject:[NSString stringWithFormat:@"Could not understand the shortcut for \"%@\".", actionId]];
+		}
+		// flag any keys in the file that don't match a known action
+		[self flagUnknownActionIds:keybindings];
+	}
+}
+
+// Read + comment-strip + JSON-parse the file; returns the "keybindings" object or nil.
+- (NSDictionary *)readKeybindings {
+	NSURL *url = self.fileURL;
+	if (![url checkResourceIsReachableAndReturnError:NULL]) return nil; // missing == all defaults
+	NSError *err = nil;
+	NSString *text = [NSString stringWithContentsOfURL:url encoding:NSUTF8StringEncoding error:&err];
+	if (!text) {
+		[_errors addObject:[NSString stringWithFormat:@"Could not read the configuration file: %@", err.localizedDescription]];
+		return nil;
+	}
+	NSData *json = [[self stripJSONComments:text] dataUsingEncoding:NSUTF8StringEncoding];
+	id root = [NSJSONSerialization JSONObjectWithData:json options:0 error:&err];
+	if (![root isKindOfClass:NSDictionary.class]) {
+		[_errors addObject:[NSString stringWithFormat:@"The configuration file is not valid JSON: %@", err.localizedDescription]];
+		return nil;
+	}
+	id kb = root[@"keybindings"];
+	if (kb && ![kb isKindOfClass:NSDictionary.class]) {
+		[_errors addObject:@"\"keybindings\" must be an object."];
+		return nil;
+	}
+	return kb ?: @{};
+}
+
+// Remove // comments (line and trailing), ignoring // inside JSON strings.
+- (NSString *)stripJSONComments:(NSString *)text {
+	NSMutableString *out = [NSMutableString stringWithCapacity:text.length];
+	BOOL inString = NO, escaped = NO, inComment = NO;
+	NSUInteger n = text.length;
+	for (NSUInteger i = 0; i < n; ++i) {
+		unichar c = [text characterAtIndex:i];
+		if (inComment) {
+			if (c == '\n') { inComment = NO; [out appendFormat:@"%C", c]; }
+			continue;
+		}
+		if (inString) {
+			[out appendFormat:@"%C", c];
+			if (escaped) escaped = NO;
+			else if (c == '\\') escaped = YES;
+			else if (c == '"') inString = NO;
+			continue;
+		}
+		if (c == '"') { inString = YES; [out appendFormat:@"%C", c]; continue; }
+		if (c == '/' && i + 1 < n && [text characterAtIndex:i+1] == '/') { inComment = YES; ++i; continue; }
+		[out appendFormat:@"%C", c];
+	}
+	return out;
+}
+
+- (void)buildViewerDispatch:(NSMutableDictionary<NSString*,NSNumber*> *)dispatch
+					  table:(const DYKeyActionDef *)table count:(size_t)count
+				  overrides:(NSDictionary *)keybindings
+				   idToCode:(NSMutableDictionary<NSString*,NSNumber*> *)idToCode {
+	for (size_t i = 0; i < count; ++i) {
+		NSString *actionId = @(table[i].actionId);
+		NSNumber *code = @(table[i].code);
+		id override = keybindings[actionId];
+		NSArray<NSString *> *keystrokes;
+		if (override == nil) {
+			keystrokes = [@(table[i].defaultKeys) componentsSeparatedByString:@","]; // built-in default
+		} else if (override == NSNull.null) {
+			keystrokes = @[]; // explicit unbind
+		} else if ([override isKindOfClass:NSString.class]) {
+			keystrokes = @[override];
+		} else if ([override isKindOfClass:NSArray.class]) {
+			keystrokes = override;
+		} else {
+			[_errors addObject:[NSString stringWithFormat:@"The value for \"%@\" must be a string, a list, or null.", actionId]];
+			keystrokes = @[];
+		}
+		for (NSString *ks in keystrokes) {
+			NSString *ch = ViewerCharForKeystroke(ks);
+			if (!ch) {
+				[_errors addObject:[NSString stringWithFormat:@"\"%@\" is not a valid single-key shortcut for \"%@\".", ks, actionId]];
+				continue;
+			}
+			if ([ReservedViewerChars() characterIsMember:[ch characterAtIndex:0]]) {
+				[_errors addObject:[NSString stringWithFormat:@"\"%@\" is reserved for navigation and can't be reassigned (\"%@\").", ks, actionId]];
+				continue;
+			}
+			if (dispatch[ch]) {
+				[_errors addObject:[NSString stringWithFormat:@"The key \"%@\" is bound to more than one action; keeping the first.", ch]];
+				continue; // first occurrence wins
+			}
+			dispatch[ch] = code;
+		}
+	}
+}
+
+- (void)flagUnknownActionIds:(NSDictionary *)keybindings {
+	NSMutableSet<NSString *> *known = [NSMutableSet set];
+	for (size_t i = 0; i < sizeof(kMenuActions)/sizeof(kMenuActions[0]); ++i) [known addObject:@(kMenuActions[i].actionId)];
+	for (size_t i = 0; i < sizeof(kSlideshowActions)/sizeof(kSlideshowActions[0]); ++i) [known addObject:@(kSlideshowActions[i].actionId)];
+	for (size_t i = 0; i < sizeof(kBrowserActions)/sizeof(kBrowserActions[0]); ++i) [known addObject:@(kBrowserActions[i].actionId)];
+	for (NSString *key in keybindings) {
+		if (![known containsObject:key])
+			[_errors addObject:[NSString stringWithFormat:@"Unknown action \"%@\" (ignored).", key]];
+	}
+}
+
+#pragma mark Applying
+
+static NSMenuItem *MenuItemWithTag(NSMenu *menu, NSInteger tag) {
+	for (NSMenuItem *item in menu.itemArray) {
+		if (item.tag == tag) return item;
+		if (item.submenu) {
+			NSMenuItem *found = MenuItemWithTag(item.submenu, tag);
+			if (found) return found;
+		}
+	}
+	return nil;
+}
+
+- (void)applyToMainMenu {
+	NSMenu *mainMenu = NSApp.mainMenu;
+	if (!mainMenu) return;
+	// capture the built-in (.xib) shortcuts once, before we ever change them, so an
+	// action the file omits reverts to its default instead of sticking on reload
+	if (!_menuDefaults) {
+		_menuDefaults = [NSMutableDictionary dictionary];
+		for (size_t i = 0; i < sizeof(kMenuActions)/sizeof(kMenuActions[0]); ++i) {
+			NSMenuItem *item = MenuItemWithTag(mainMenu, kMenuActions[i].tag);
+			if (item)
+				_menuDefaults[@(kMenuActions[i].actionId)] = @[item.keyEquivalent ?: @"", @(item.keyEquivalentModifierMask)];
+		}
+	}
+	for (size_t i = 0; i < sizeof(kMenuActions)/sizeof(kMenuActions[0]); ++i) {
+		NSString *actionId = @(kMenuActions[i].actionId);
+		NSMenuItem *item = MenuItemWithTag(mainMenu, kMenuActions[i].tag);
+		if (!item) continue;
+		id override = _menuOverrides[actionId];
+		NSString *key; NSEventModifierFlags mask;
+		if (override == NSNull.null) {
+			key = @""; mask = 0;                          // explicit unbind
+		} else if (override) {
+			key = override[0]; mask = (NSEventModifierFlags)[override[1] unsignedIntegerValue];
+		} else {
+			NSArray *def = _menuDefaults[actionId];       // not in the file -> revert to built-in
+			key = def ? def[0] : @"";
+			mask = def ? (NSEventModifierFlags)[def[1] unsignedIntegerValue] : 0;
+		}
+		item.keyEquivalent = key;
+		item.keyEquivalentModifierMask = mask;
+	}
+}
+
+#pragma mark Dispatch
+
+- (SlideshowAction)slideshowActionForEvent:(NSEvent *)e {
+	NSString *chars = e.characters;
+	if (chars.length == 0) return SlideshowActionNone;
+	NSNumber *code = _slideshowDispatch[chars];
+	return code ? (SlideshowAction)code.integerValue : SlideshowActionNone;
+}
+
+- (BrowserAction)browserActionForEvent:(NSEvent *)e {
+	NSString *chars = e.characters;
+	if (chars.length == 0) return BrowserActionNone;
+	NSNumber *code = _browserDispatch[chars];
+	return code ? (BrowserAction)code.integerValue : BrowserActionNone;
+}
+
+#pragma mark Errors & file access
+
+- (void)reportErrorsIfAny {
+	if (_errors.count == 0) return;
+	NSAlert *alert = [[NSAlert alloc] init];
+	alert.messageText = NSLocalizedString(@"There were problems in the configuration file.", @"");
+	alert.informativeText = [_errors componentsJoinedByString:@"\n"];
+	[alert addButtonWithTitle:NSLocalizedString(@"OK", @"")];
+	[alert runModal];
+}
+
+- (void)openInEditor {
+	[self writeTemplateIfMissing];
+	[NSWorkspace.sharedWorkspace openURL:self.fileURL];
+}
+
+- (void)revealInFinder {
+	[self writeTemplateIfMissing];
+	[NSWorkspace.sharedWorkspace activateFileViewerSelectingURLs:@[self.fileURL]];
+}
+
+- (void)writeTemplateIfMissing {
+	NSURL *url = self.fileURL;
+	if ([url checkResourceIsReachableAndReturnError:NULL]) return;
+	// migrate a pre-existing keybindings.json to the new .jsonc name, preserving edits
+	NSURL *legacy = self.legacyFileURL;
+	if ([legacy checkResourceIsReachableAndReturnError:NULL] &&
+		[NSFileManager.defaultManager moveItemAtURL:legacy toURL:url error:NULL])
+		return;
+	[NSFileManager.defaultManager createDirectoryAtURL:url.URLByDeletingLastPathComponent
+						   withIntermediateDirectories:YES attributes:nil error:NULL];
+	[[self templateText] writeToURL:url atomically:YES encoding:NSUTF8StringEncoding error:NULL];
+}
+
+// A self-documenting snapshot of the current shortcuts. Every action is written as
+// a real (active) entry so the file reflects the current keybindings; deleting a
+// line reverts that action to its built-in default.
+- (NSString *)templateText {
+	NSMutableArray<NSArray *> *entries = [NSMutableArray array]; // @[section, "\"key\": value"]
+	for (size_t i = 0; i < sizeof(kMenuActions)/sizeof(kMenuActions[0]); ++i) {
+		NSString *cur = [self currentMenuKeystrokeForTag:kMenuActions[i].tag];
+		NSString *val = cur ? [NSString stringWithFormat:@"\"%@\"", cur] : @"null";
+		[entries addObject:@[@"Menu shortcuts", [NSString stringWithFormat:@"\"%@\": %@", @(kMenuActions[i].actionId), val]]];
+	}
+	[self appendViewerEntries:entries table:kSlideshowActions count:sizeof(kSlideshowActions)/sizeof(kSlideshowActions[0]) section:@"Slideshow keys"];
+	[self appendViewerEntries:entries table:kBrowserActions count:sizeof(kBrowserActions)/sizeof(kBrowserActions[0]) section:@"Browser (thumbnail window) keys"];
+
+	NSMutableString *s = [NSMutableString stringWithString:
+		@"{\n"
+		"  // Phoenix Slides keyboard shortcuts. This file was created from your current\n"
+		"  // shortcuts. Edit a value and use Phoenix Slides > Reload Configuration to\n"
+		"  // apply it (no restart needed).\n"
+		"  //\n"
+		"  // Value: a keystroke string, a list of strings, or null for no shortcut.\n"
+		"  // Modifiers: cmd, ctrl, opt, shift. Examples: \"cmd+shift+i\", \"n\", \"D\".\n"
+		"  // Single-key (slideshow/browser) shortcuts take no cmd/ctrl/opt.\n"
+		"  // Delete a line to fall back to the built-in default.\n"
+		"  \"keybindings\": {\n"];
+	NSString *lastSection = nil;
+	for (NSUInteger i = 0; i < entries.count; ++i) {
+		NSString *section = entries[i][0], *line = entries[i][1];
+		if (![section isEqualToString:lastSection]) {
+			[s appendFormat:@"\n    // --- %@ ---\n", section];
+			lastSection = section;
+		}
+		[s appendFormat:@"    %@%@\n", line, (i + 1 < entries.count) ? @"," : @""];
+	}
+	[s appendString:@"  }\n}\n"];
+	return s;
+}
+
+- (void)appendViewerEntries:(NSMutableArray<NSArray *> *)entries table:(const DYKeyActionDef *)table count:(size_t)count section:(NSString *)section {
+	for (size_t i = 0; i < count; ++i) {
+		NSArray<NSString *> *keys = [@(table[i].defaultKeys) componentsSeparatedByString:@","];
+		NSString *value;
+		if (keys.count == 1) {
+			value = [NSString stringWithFormat:@"\"%@\"", keys[0]];
+		} else {
+			NSMutableArray *quoted = [NSMutableArray array];
+			for (NSString *k in keys) [quoted addObject:[NSString stringWithFormat:@"\"%@\"", k]];
+			value = [NSString stringWithFormat:@"[%@]", [quoted componentsJoinedByString:@", "]];
+		}
+		[entries addObject:@[section, [NSString stringWithFormat:@"\"%@\": %@", @(table[i].actionId), value]]];
+	}
+}
+
+// Format a menu item's current key equivalent back into keystroke syntax (best effort).
+- (NSString *)currentMenuKeystrokeForTag:(NSInteger)tag {
+	NSMenuItem *item = MenuItemWithTag(NSApp.mainMenu, tag);
+	if (!item || item.keyEquivalent.length == 0) return nil;
+	NSMutableArray<NSString *> *parts = [NSMutableArray array];
+	NSEventModifierFlags m = item.keyEquivalentModifierMask;
+	if (m & NSEventModifierFlagControl) [parts addObject:@"ctrl"];
+	if (m & NSEventModifierFlagOption)  [parts addObject:@"opt"];
+	if (m & NSEventModifierFlagShift)   [parts addObject:@"shift"];
+	if (m & NSEventModifierFlagCommand) [parts addObject:@"cmd"];
+	unichar c = [item.keyEquivalent characterAtIndex:0];
+	NSString *keyName;
+	switch (c) {
+		case 0x08: keyName = @"delete"; break;
+		case 0x7f: keyName = @"forwarddelete"; break;
+		case 0x0d: keyName = @"return"; break;
+		case 0x1b: keyName = @"esc"; break;
+		case 0x20: keyName = @"space"; break;
+		default:
+			if (c >= NSF1FunctionKey && c <= NSF12FunctionKey)
+				keyName = [NSString stringWithFormat:@"f%d", (int)(c - NSF1FunctionKey + 1)];
+			else
+				keyName = item.keyEquivalent; // ordinary character (uppercase already implies shift)
+	}
+	[parts addObject:keyName];
+	return [parts componentsJoinedByString:@"+"];
+}
+
+@end

--- a/KeyBindings.m
+++ b/KeyBindings.m
@@ -41,6 +41,8 @@ static const DYMenuActionDef kMenuActions[] = {
 	{"menu.sortByType",       205},
 	{"menu.sortBySize",       206},
 	{"menu.sortByFilePath",   207},
+	{"menu.showDirectoryBrowser", 25},  // tag added in MainMenu.xib
+	{"menu.showPathBar",       26},  // tag added in MainMenu.xib
 	{"menu.saveRotation",     117},
 	{"menu.advancedOptions",  100},
 	{"menu.toggleLoop",         3},

--- a/README.md
+++ b/README.md
@@ -28,6 +28,77 @@ and massaging those results. (I don't actually speak Italian!)
 
 The master branch will generally require the latest version of Xcode.
 
+The easiest way to build is to open `creevey.xcodeproj` in Xcode and press ⌘R.
+The commands below cover building, running, and packaging from the command line;
+run them from the repository root. The single scheme/target is named
+`Phoenix Slides` and the product is `Phoenix Slides.app`.
+
+### Build
+
+`CODE_SIGNING_ALLOWED=NO` produces an unsigned build for local use, so you don't
+need a signing certificate; drop it (and see the packaging section) when building
+to distribute.
+
+```sh
+# Release build into a predictable ./build folder
+xcodebuild -project creevey.xcodeproj -scheme "Phoenix Slides" \
+  -configuration Release -derivedDataPath build build CODE_SIGNING_ALLOWED=NO
+
+# Debug build
+xcodebuild -project creevey.xcodeproj -scheme "Phoenix Slides" \
+  -configuration Debug -derivedDataPath build build CODE_SIGNING_ALLOWED=NO
+
+# Clean
+xcodebuild -project creevey.xcodeproj -scheme "Phoenix Slides" clean
+rm -rf build
+```
+
+The built app lands at `build/Build/Products/Release/Phoenix Slides.app`.
+
+### Run
+
+```sh
+open "build/Build/Products/Release/Phoenix Slides.app"
+```
+
+### Test
+
+There is no XCTest target, so a successful Release build (which also compiles
+the nibs) is the effective smoke test. To quickly syntax-check a single source
+file without a full build:
+
+```sh
+xcrun --sdk macosx clang -fsyntax-only -fobjc-arc -fmodules \
+  -I. -IDYjpegtran -Iexiftags -Ilibjpeg CreeveyController.m
+```
+
+### Packaging a DMG for distribution
+
+```sh
+APP="build/Build/Products/Release/Phoenix Slides.app"
+VERSION=$(xcodebuild -project creevey.xcodeproj -scheme "Phoenix Slides" \
+  -showBuildSettings 2>/dev/null | awk '/ MARKETING_VERSION /{print $3}')
+
+rm -rf dist && mkdir -p dist/dmg
+cp -R "$APP" dist/dmg/
+ln -s /Applications dist/dmg/Applications
+hdiutil create -volname "Phoenix Slides" -srcfolder dist/dmg \
+  -ov -format UDZO "Phoenix-Slides-$VERSION.dmg"
+```
+
+For public distribution the app must be signed with a Developer ID (build with
+`CODE_SIGN_IDENTITY`, `DEVELOPMENT_TEAM`, and `OTHER_CODE_SIGN_FLAGS="--options runtime"`),
+and the resulting DMG notarized and stapled so Gatekeeper accepts it:
+
+```sh
+xcrun notarytool submit "Phoenix-Slides-$VERSION.dmg" \
+  --apple-id "you@example.com" --team-id TEAMID \
+  --password "app-specific-password" --wait
+xcrun stapler staple "Phoenix-Slides-$VERSION.dmg"
+```
+
+### Legacy toolchains
+
 Commit 7d0cc7e should compile for 10.6+. https://github.com/gobbledegook/creevey/releases/tag/v1.3.1i
 
 Branch xcode326 will compile a universal binary with PPC support but requires Xcode 3.2.6. https://github.com/gobbledegook/creevey/tree/xcode326

--- a/SlideshowWindow.h
+++ b/SlideshowWindow.h
@@ -6,6 +6,7 @@
 //California 94305, USA.
 
 @import Cocoa;
+#import "KeyBindings.h"
 
 @interface SlideshowWindow : NSWindow
 @property (nonatomic) BOOL fullscreenMode;
@@ -39,6 +40,8 @@
 @property (nonatomic) BOOL autoRotate;
 @property (nonatomic) NSTimeInterval autoadvanceTime;
 - (void)updateTimer;
+
+- (void)performSlideshowAction:(SlideshowAction)action; // rebindable viewer action (zoom/scroll/…)
 
 // menu methods
 - (IBAction)endSlideshow:(id)sender;

--- a/SlideshowWindow.h
+++ b/SlideshowWindow.h
@@ -21,6 +21,7 @@
 - (void)startSlideshowAtIndex:(NSUInteger)n;
 - (void)endSlideshow;
 - (void)resetScreen;
+- (void)reloadInterfaceTextSize;
 
 @property (nonatomic, readonly) NSUInteger currentIndex;
 @property (nonatomic, readonly) NSString *currentFile;

--- a/SlideshowWindow.m
+++ b/SlideshowWindow.m
@@ -570,6 +570,16 @@ scheduledTimerWithTimeInterval:timerIntvl
 	[attStr addAttribute:NSShadowAttributeName
 				   value:shdw
 				   range:r];
+	// scale the EXIF text to the interface text size
+	CGFloat scale = DYInterfaceTextScale();
+	if (scale != 1.0)
+		[attStr enumerateAttribute:NSFontAttributeName inRange:r options:0
+						usingBlock:^(NSFont *font, NSRange range, BOOL *stop) {
+			if (font)
+				[attStr addAttribute:NSFontAttributeName
+							   value:[NSFontManager.sharedFontManager convertFont:font toSize:font.pointSize * scale]
+							   range:range];
+		}];
 	[exifFld replaceCharactersInRange:NSMakeRange(0,exifFld.string.length)
 							  withRTF:[attStr RTFFromRange:NSMakeRange(0,attStr.length)
 										documentAttributes:@{}]];
@@ -869,6 +879,7 @@ scheduledTimerWithTimeInterval:timerIntvl
 	catsFld.font = [NSFont systemFontOfSize:sz];
 	[infoFld sizeToFit];
 	[self updateInfoFld];
+	if (!exifFld.enclosingScrollView.hidden) [self updateExifFld]; // top-right EXIF info
 	// rebuild the cheat sheet at the new size next time it's shown (or now, if visible)
 	BOOL wasVisible = helpFld && !helpFld.hidden;
 	[helpFld removeFromSuperview];

--- a/SlideshowWindow.m
+++ b/SlideshowWindow.m
@@ -145,17 +145,26 @@ static BOOL UsingMagicMouse(NSEvent *e) {
 	[NSNotificationCenter.defaultCenter addObserver:self selector:@selector(imgViewResized:) name:NSViewFrameDidChangeNotification object:imgView];
 	imgView.delegate = self;
 	
+	CGFloat infoFontSize = round(NSFont.systemFontSize * DYInterfaceTextScale());
+	// white on a translucent dark background reads well over any image, in Light or Dark
+	NSColor *overlayBg = [NSColor colorWithCalibratedWhite:0.0 alpha:0.55];
 	infoFld = [[NSTextField alloc] initWithFrame:NSMakeRect(0,0,360,20)];
 	[imgView addSubview:infoFld];
 	infoFld.autoresizingMask = NSViewMaxXMargin|NSViewMaxYMargin;
-	infoFld.backgroundColor = NSColor.grayColor;
+	infoFld.drawsBackground = YES;
+	infoFld.backgroundColor = overlayBg;
+	infoFld.textColor = NSColor.whiteColor;
+	infoFld.font = [NSFont systemFontOfSize:infoFontSize];
 	infoFld.bezeled = NO;
 	infoFld.editable = NO;
-	
+
 	catsFld = [[NSTextField alloc] initWithFrame:NSMakeRect(0,imgView.bounds.size.height-20,300,20)];
 	[imgView addSubview:catsFld];
 	catsFld.autoresizingMask = NSViewMaxXMargin|NSViewMinYMargin;
-	catsFld.backgroundColor = NSColor.grayColor;
+	catsFld.drawsBackground = YES;
+	catsFld.backgroundColor = overlayBg;
+	catsFld.textColor = NSColor.whiteColor;
+	catsFld.font = [NSFont systemFontOfSize:infoFontSize];
 	catsFld.bezeled = NO;
 	catsFld.editable = NO; // **
 	catsFld.hidden = YES;
@@ -854,6 +863,19 @@ scheduledTimerWithTimeInterval:timerIntvl
 		[self updateExifFld];
 }
 
+- (void)reloadInterfaceTextSize {
+	CGFloat sz = round(NSFont.systemFontSize * DYInterfaceTextScale());
+	infoFld.font = [NSFont systemFontOfSize:sz];
+	catsFld.font = [NSFont systemFontOfSize:sz];
+	[infoFld sizeToFit];
+	[self updateInfoFld];
+	// rebuild the cheat sheet at the new size next time it's shown (or now, if visible)
+	BOOL wasVisible = helpFld && !helpFld.hidden;
+	[helpFld removeFromSuperview];
+	helpFld = nil;
+	if (wasVisible) [self toggleHelp];
+}
+
 - (void)toggleHelp {
 	if (!helpFld) {
 		helpFld = [[NSTextView alloc] initWithFrame:NSZeroRect];
@@ -863,6 +885,20 @@ scheduledTimerWithTimeInterval:timerIntvl
 			NSLog(@"couldn't load cheat sheet!");
 		helpFld.backgroundColor = NSColor.lightGrayColor;
 		helpFld.selectable = NO;
+		// scale the cheat sheet to the interface text size
+		CGFloat scale = DYInterfaceTextScale();
+		if (scale != 1.0) {
+			NSTextStorage *ts = helpFld.textStorage;
+			[ts beginEditing];
+			[ts enumerateAttribute:NSFontAttributeName inRange:NSMakeRange(0, ts.length) options:0
+						 usingBlock:^(NSFont *font, NSRange range, BOOL *stop) {
+				if (font)
+					[ts addAttribute:NSFontAttributeName
+							   value:[NSFontManager.sharedFontManager convertFont:font toSize:font.pointSize * scale]
+							   range:range];
+			}];
+			[ts endEditing];
+		}
 //		NSLayoutManager *lm = [helpFld layoutManager];
 //		NSRange rnge = [lm glyphRangeForCharacterRange:NSMakeRange(0,[[helpFld textStorage] length])
 //								  actualCharacterRange:NULL];

--- a/SlideshowWindow.m
+++ b/SlideshowWindow.m
@@ -1158,34 +1158,24 @@ scheduledTimerWithTimeInterval:timerIntvl
 		case SlideshowActionResetView:
 			[self redisplayImage]; // this resets zoom, rotate, and flip
 			break;
+		case SlideshowActionScrollUp:
+		case SlideshowActionScrollDown:
+		case SlideshowActionScrollLeft:
+		case SlideshowActionScrollRight: {
+			if (!imgView.dragMode) break; // pan only when the image overflows the view
+			NSSize b = imgView.bounds.size;
+			CGFloat dx = b.width/4, dy = b.height/4; // a quarter view per press
+			if (action == SlideshowActionScrollUp)        [imgView fakeDragX:0 y:dy];
+			else if (action == SlideshowActionScrollDown) [imgView fakeDragX:0 y:-dy];
+			else if (action == SlideshowActionScrollLeft) [imgView fakeDragX:-dx y:0];
+			else                                          [imgView fakeDragX:dx y:0];
+			break;
+		}
 	}
 }
 
-- (BOOL)performKeyEquivalent:(NSEvent *)e {
-	unichar c = [e.characters characterAtIndex:0];
-	//NSLog([e charactersIgnoringModifiers]);
-	//NSLog([e characters]);
-	// charactersIgnoringModifiers is 10.4 or later, and doesn't play well with Dvorak Qwerty-cmd
-	DYImageInfo *obj;
-	switch (c) {
-		case '=':
-			if (!(e.modifierFlags & NSEventModifierFlagNumericPad))
-				c = '+';
-			// intentional fall-through
-		case '+':
-		case '-':
-			if (currentIndex >= filenames.count) { NSBeep(); return YES; }
-			if ((obj = [imgCache infoForKey:ResolveAliasToPath(filenames[currentIndex])])) {
-				if (c == '+') [imgView zoomIn];
-				else if (c == '-') [imgView zoomOut];
-				else [imgView zoomActualSize];
-				[self saveZoomAndLoadFullSize:obj];
-			}
-			return YES;
-		default:
-			return [super performKeyEquivalent:e];
-	}
-}
+// Note: single-key zoom (+ − =) and reset (*) are handled through the rebindable
+// slideshow actions in keyDown:/performSlideshowAction:, so they stay configurable.
 
 
 // mouse control added for 1.2.2 (2006 Aug)

--- a/SlideshowWindow.m
+++ b/SlideshowWindow.m
@@ -223,7 +223,7 @@ static BOOL UsingMagicMouse(NSEvent *e) {
 		self.collectionBehavior = NSWindowCollectionBehaviorParticipatesInCycle|NSWindowCollectionBehaviorFullScreenNone|NSWindowCollectionBehaviorMoveToActiveSpace;
 		self.hasShadow = NO; // avoid weird border from macOS 26's "liquid glass" effect
 	} else {
-		self.styleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskResizable;
+		self.styleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskResizable | NSWindowStyleMaskMiniaturizable;
 		self.collectionBehavior = NSWindowCollectionBehaviorParticipatesInCycle|NSWindowCollectionBehaviorFullScreenNone|NSWindowCollectionBehaviorMoveToActiveSpace;
 		self.hasShadow = YES;
 	}

--- a/SlideshowWindow.m
+++ b/SlideshowWindow.m
@@ -11,6 +11,7 @@
 #import "SlideshowWindow.h"
 #import "DYImageView.h"
 #import "DYImageCache.h"
+#import "KeyBindings.h"
 #import "DYCarbonGoodies.h"
 #import "CreeveyController.h"
 #import "DYRandomizableArray.h"
@@ -876,6 +877,11 @@ scheduledTimerWithTimeInterval:timerIntvl
 		s = self.contentView.frame.size;
 		r.origin.x = s.width - r.size.width - 50;
 		r.origin.y = s.height - r.size.height - 55;
+		// if the cheat sheet fits but its bottom would fall below the window, nudge it
+		// up so nothing is clipped; if it's taller than the window, leave it top-anchored
+		// (the navigation keys at the top matter most)
+		if (r.origin.y < 20 && r.size.height <= s.height - 20)
+			r.origin.y = 20;
 		helpFld.frame = NSIntegralRect(r);
 		helpFld.autoresizingMask = NSViewMinXMargin|NSViewMinYMargin;
 		return;
@@ -974,7 +980,11 @@ scheduledTimerWithTimeInterval:timerIntvl
 	if (c == ' ' && ((e.modifierFlags & NSEventModifierFlagShift) != 0)) {
 		c = NSLeftArrowFunctionKey;
 	}
-	DYImageInfo *obj;
+	SlideshowAction act = [((CreeveyController *)NSApp.delegate).keyBindings slideshowActionForEvent:e];
+	if (act != SlideshowActionNone) {
+		[self performSlideshowAction:act];
+		return;
+	}
 	switch (c) {
 		case '!':
 			[self setTimer:0.5];
@@ -1014,7 +1024,22 @@ scheduledTimerWithTimeInterval:timerIntvl
 		case '\x1b': // escape
 			[self endSlideshow];
 			break;
-		case 'i':
+		case NSHelpFunctionKey: // the physical Help key isn't rebindable
+			[self performSlideshowAction:SlideshowActionHelp];
+			break;
+		default:
+			[super keyDown:e];
+	}
+}
+
+// The rebindable slideshow actions, dispatched by keyDown: via the config's
+// keystroke lookup. Non-rebindable navigation stays in keyDown:'s switch.
+- (void)performSlideshowAction:(SlideshowAction)action {
+	DYImageInfo *obj;
+	switch (action) {
+		case SlideshowActionNone:
+			break;
+		case SlideshowActionToggleInfo:
 			// cycles three ways: info, info + exif, none
 			hideInfoFld = !infoFld.hidden && !exifFld.enclosingScrollView.hidden;
 			if (!infoFld.hidden)
@@ -1030,7 +1055,7 @@ scheduledTimerWithTimeInterval:timerIntvl
 				[NSUserDefaults.standardUserDefaults setInteger:infoFldVisible forKey:@"DYSlideshowWindowVisibleFields"];
 			}
 			break;
-		case 'p':
+		case SlideshowActionTogglePath:
 			if (infoFld.hidden) {
 				infoFld.hidden = NO;
 				_showPath = YES;
@@ -1040,13 +1065,10 @@ scheduledTimerWithTimeInterval:timerIntvl
 			[self updateInfoFld];
 			[NSUserDefaults.standardUserDefaults setBool:_showPath forKey:@"DYSlideshowWindowVisiblePath"];
 			break;
-		case 'h':
-		case '?':
-		case '/':
-		case NSHelpFunctionKey: // doesn't work, trapped at a higher level?
+		case SlideshowActionHelp:
 			[self toggleHelp];
 			break;
-		case 'I':
+		case SlideshowActionMoreExif:
 			if (exifFld.enclosingScrollView.hidden) {
 				moreExif = YES;
 				hideInfoFld = NO;
@@ -1058,35 +1080,37 @@ scheduledTimerWithTimeInterval:timerIntvl
 			}
 			[NSUserDefaults.standardUserDefaults setInteger:2 forKey:@"DYSlideshowWindowVisibleFields"];
 			break;
-		case 'l':
+		case SlideshowActionRotateLeft:
 			[self setRotation:90];
 			break;
-		case 'r':
+		case SlideshowActionRotateRight:
 			[self setRotation:-90];
 			break;
-		case 'f':
+		case SlideshowActionRename:
+			[(CreeveyController *)NSApp.delegate renameSelectedFile:nil];
+			break;
+		case SlideshowActionMoveToTrash:
+			[(CreeveyController *)NSApp.delegate moveToTrash:nil];
+			break;
+		case SlideshowActionDeletePermanently:
+			[(CreeveyController *)NSApp.delegate deleteSelectedFilesPermanently:nil];
+			break;
+		case SlideshowActionFlip:
 			[self toggleFlip];
 			break;
-		case '=':
-			//if ([imgView showActualSize])
-			//	[zooms removeObjectForKey:[filenames objectAtIndex:currentIndex]];
-			// actually, '=' doesn't center the pic, so this is wrong
-			// if you zoom or move a pic while in actualsize mode, you're basically stuck with a non-default zoom
-			// intentional fall-through to next cases
-		case '+':
-		case '-':
+		case SlideshowActionActualSize:
+		case SlideshowActionZoomIn:
+		case SlideshowActionZoomOut:
 			if ((obj = [imgCache infoForKey:ResolveAliasToPath(filenames[currentIndex])])) {
-				if (c == '+') [imgView zoomIn];
-				else if (c == '-') [imgView zoomOut];
+				if (action == SlideshowActionZoomIn) [imgView zoomIn];
+				else if (action == SlideshowActionZoomOut) [imgView zoomOut];
 				else [imgView zoomActualSize];
 				[self saveZoomAndLoadFullSize:obj];
 			}
 			break;
-		case '*':
+		case SlideshowActionResetView:
 			[self redisplayImage]; // this resets zoom, rotate, and flip
 			break;
-		default:
-			[super keyDown:e];
 	}
 }
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,15 @@
+# Known Issues / TODO
+
+Running notes on issues and follow-ups to revisit.
+
+## Done
+
+- **Finder-style multi-file "Rename…" feature.** Done 2026-08-15 — `BatchRename` model +
+  `BatchRenameController` sheet with Add Text / Replace Text / Format modes, live example, keep-name
+  option, undo-grouped renames. File ▸ Rename… and the thumbnail context menu open it for one or
+  more files; configurable `browser.renameItems` (default ⇧E); the quick single-file rename (`e`)
+  is unchanged.
+
+- **Go to Folder doesn't follow symlinks.** Fixed 2026-08-15 — `-[CreeveyMainWindowController
+  setPath:]` now canonicalizes with `realpath()` (e.g. `/tmp` → `/private/tmp`) before navigating,
+  since `stringByResolvingSymlinksInPath` intentionally leaves `/tmp`, `/var`, `/etc` alone.

--- a/creevey.xcodeproj/project.pbxproj
+++ b/creevey.xcodeproj/project.pbxproj
@@ -505,6 +505,7 @@
 				8D1107290486CEB800E47090 /* Resources */,
 				8D11072C0486CEB800E47090 /* Sources */,
 				8D11072E0486CEB800E47090 /* Frameworks */,
+				BA5FABC600000000000000C6 /* Stamp git commit hash */,
 			);
 			buildRules = (
 			);
@@ -636,6 +637,25 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		BA5FABC600000000000000C6 /* Stamp git commit hash */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Stamp git commit hash";
+			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GitInfo.plist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Stamp the short git commit hash into a GitInfo.plist resource for the About panel\nHASH=$(git -C \"$SRCROOT\" rev-parse --short HEAD 2>/dev/null)\nOUT=\"$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/GitInfo.plist\"\nrm -f \"$OUT\"\nif [ -n \"$HASH\" ]; then\n  /usr/libexec/PlistBuddy -c \"Add :GitCommitHash string $HASH\" \"$OUT\"\n  echo \"note: stamped git commit $HASH\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXVariantGroup section */
 		089C165CFE840E0CC02AAC07 /* InfoPlist.strings */ = {
@@ -828,7 +848,7 @@
 				DEVELOPMENT_TEAM = 9436CS8LQX;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -877,7 +897,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 9436CS8LQX;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;

--- a/creevey.xcodeproj/project.pbxproj
+++ b/creevey.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		F22BDC162B435F3900F53E37 /* PrefsWin.xib in Resources */ = {isa = PBXBuildFile; fileRef = F22BDC142B435F3900F53E37 /* PrefsWin.xib */; };
 		F234C0170810E9B700175D50 /* DYImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = F234C0150810E9B700175D50 /* DYImageCache.h */; };
 		F234C0180810E9B700175D50 /* DYImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = F234C0160810E9B700175D50 /* DYImageCache.m */; };
+		FADC0100000000000000B001 /* KeyBindings.m in Sources */ = {isa = PBXBuildFile; fileRef = FADC0100000000000000A002 /* KeyBindings.m */; };
 		F23DC5130A86CEF7005E49FD /* slideshow.tif in Resources */ = {isa = PBXBuildFile; fileRef = F23DC5120A86CEF7005E49FD /* slideshow.tif */; };
 		F23F405A2B81979E0048E5A4 /* NSColor+TextColor.h in Headers */ = {isa = PBXBuildFile; fileRef = F23F40582B81979E0048E5A4 /* NSColor+TextColor.h */; };
 		F23F405B2B81979E0048E5A4 /* NSColor+TextColor.m in Sources */ = {isa = PBXBuildFile; fileRef = F23F40592B81979E0048E5A4 /* NSColor+TextColor.m */; };
@@ -144,6 +145,8 @@
 		F22BDC1A2B43632200F53E37 /* mul */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; name = mul; path = mul.lproj/PrefsWin.xcstrings; sourceTree = "<group>"; };
 		F234C0150810E9B700175D50 /* DYImageCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DYImageCache.h; sourceTree = "<group>"; };
 		F234C0160810E9B700175D50 /* DYImageCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DYImageCache.m; sourceTree = "<group>"; };
+		FADC0100000000000000A001 /* KeyBindings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeyBindings.h; sourceTree = "<group>"; };
+		FADC0100000000000000A002 /* KeyBindings.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KeyBindings.m; sourceTree = "<group>"; };
 		F23DC5120A86CEF7005E49FD /* slideshow.tif */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = slideshow.tif; sourceTree = "<group>"; };
 		F23F40582B81979E0048E5A4 /* NSColor+TextColor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSColor+TextColor.h"; sourceTree = "<group>"; };
 		F23F40592B81979E0048E5A4 /* NSColor+TextColor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSColor+TextColor.m"; sourceTree = "<group>"; };
@@ -260,6 +263,8 @@
 				F262D801089AE58200CD3701 /* DYVersChecker.m */,
 				F234C0150810E9B700175D50 /* DYImageCache.h */,
 				F234C0160810E9B700175D50 /* DYImageCache.m */,
+				FADC0100000000000000A001 /* KeyBindings.h */,
+				FADC0100000000000000A002 /* KeyBindings.m */,
 				F2AE88E707EB877D008F2193 /* DirBrowserDelegate.h */,
 				F2AE88E807EB877D008F2193 /* DirBrowserDelegate.m */,
 				F2AE890C07EB9BB7008F2193 /* CreeveyController.h */,
@@ -597,6 +602,7 @@
 				F2F54191080A3846008AE60F /* DYCreeveyBrowser.m in Sources */,
 				F2FFD7C92B2805C100036217 /* dcraw.c in Sources */,
 				F234C0180810E9B700175D50 /* DYImageCache.m in Sources */,
+				FADC0100000000000000B001 /* KeyBindings.m in Sources */,
 				F28CA6B2085DF4590045386B /* NSIndexSetSymDiffExtension.m in Sources */,
 				F2FE4FCA08842F5500550533 /* DYJpegtran.m in Sources */,
 				F23F405B2B81979E0048E5A4 /* NSColor+TextColor.m in Sources */,

--- a/en.lproj/creeveyhelp.rtf
+++ b/en.lproj/creeveyhelp.rtf
@@ -28,6 +28,9 @@
 	r	rotate right (90\'b0 clockwise)\
 	l	rotate left (90\'b0 counter-clockwise)\
 	f	flip\
+	e	rename\
+	d	move to trash\
+	\uc0\u8679 D	delete permanently\
 	\uc0\u8984 E	scale up small images\
 	+/-	zoom in/out\
 	=	actual pixels\


### PR DESCRIPTION
Hi Dominic,

Thanks for the wonderful **Phoenix Slides**. I genuinely think it's one of the best image viewers on macOS. It reminds me of [IrfanView](https://www.irfanview.com/) on Windows in how fast and responsive it feels—something that's surprisingly rare among macOS image viewers.

## Summary

A collection of self-contained improvements on top of cdf45c1. Each feature is its own focused commit, so it can be reviewed, cherry-picked, or split into separate PRs. Everything is additive and follows the existing architecture (non-sandboxed, ARC, matrix-mode `NSBrowser`).

**Highlights:**

- Configurable keyboard shortcuts via a commented JSON config
- Rename and permanent-delete file operations
- Native Finder-style Quick Look preview (Space)
- Optionally show unsupported files with Quick Look thumbnails (⌥⌘U)
- Finder-style Go to Folder (⌘⇧G)
- Collapsible directory browser and a Finder-style path bar (⌥⌘B / ⌥⌘P)
- Adjustable interface text size (Small / Medium / Large / Custom)
- Open Recent submenu for folders, restoring each folder's full view state
- Proportional "bigger thumbnails" behaviour
- Full filename hover tooltips in the thumbnail grid
- About panel shows the build's git commit hash
- Filter the current folder's thumbnails by filename, with optional regex
- Browse images inside ZIP/CBZ archives as if they were folders
- Bug fixes, UI contrast improvements, and expanded build docs

## Issues addressed

- **#51 (Custom key-mapping)** — shortcuts loaded from a JSONC config file.
- **#63 (Adjustable font size)** — Small / Medium / Large preference plus a **Custom** point size (10–25 pt), scaling the UI app-wide. Folds in #86's font-size control as the **Custom** option.
- **#105 (Permanent delete hotkey)** — a configurable **Delete Immediately** command that bypasses the Trash (useful on network shares).
- **#13 (Quick Look support)** *(partial)* — native Quick Look with **Space** for any supported format (doesn't replace the in-app renderer).
- **#60 (Open Recent / recent folders)** — adds a **File → Open Recent** submenu of the last N folders visited (N configurable in Preferences, default 10), each restoring that folder's full view state (focused thumbnail, sort order, and all view toggles).
- **#21 (Filtering option)** — adds a search field to the browser's control strip that filters the current folder's thumbnails by filename as you type: case-insensitive substring by default, or a **regular expression** (e.g. `2001-.*`) via the magnifier menu's "Regular Expression" toggle. Clearing the field or changing folders restores the full listing.
- **#58 (Search/filter function)** *(partial)* — provides the requested search field (filtering by filename); the dimension/size-based filters that issue also mentions are not included.
- **#19 (Open/browse images in ZIP files)** *(partial)* — open a `.zip`/`.cbz` and browse the images inside it as if it were a folder, with background extraction and clean paths. Covers the ZIP/CBZ part of the request; RAR is not included yet.

## What's included

### Keyboard shortcuts (#51)

**[607df32](https://github.com/gsbabil/phoenix-slides/commit/607df32fe598bd7c5689d143aeb9ca7008b4c599)**

- Loads `~/Library/Application Support/Phoenix Slides/keybindings.jsonc` at launch (writing a commented template if missing), rebinding both menu shortcuts and single-key browser/slideshow actions. Adds **Edit / Reload / Reveal Configuration** commands for live editing.

### File operations (#105)

**[91371f6](https://github.com/gsbabil/phoenix-slides/commit/91371f6fb31ff2ea1cd920e0e709b2273625e18d)**, **[50b0cf6](https://github.com/gsbabil/phoenix-slides/commit/50b0cf6634f228f9d2e80da538cf88dc048c576a)**

- Adds **Rename** and **Delete Immediately** (⌥⌘⌫; with confirmation) to the File menu. Rename uses a fixed-size wrapping dialog with a live character count, is undoable, and keeps the renamed file selected.

### Quick Look preview (#13, partial)

**[04ed185](https://github.com/gsbabil/phoenix-slides/commit/04ed18524fde9a08b2bb83127eec855ea1d2c698)**, **[0f74406](https://github.com/gsbabil/phoenix-slides/commit/0f74406a13e28a97db0e223a3396dd68a31b8582)**, **[30c56ee](https://github.com/gsbabil/phoenix-slides/commit/30c56ee3885a2b6bc823324c0f979d11655528b7)**, **[878d9b5](https://github.com/gsbabil/phoenix-slides/commit/878d9b56b7b244819a083e28312616f18b357680)**

- **Space** opens a native Quick Look panel; **←/→** navigate while keeping the grid selection in sync (so closing it leaves the last-viewed file selected); **Enter** still starts the slideshow. Includes a fix so unmodified **Space** activates Quick Look instead of the slideshow. Fully configurable via the keybindings system.
- **View → Show Unsupported Files** (⌥⌘U) also lists files the app can't display (video, PDF, text, …) with real Quick Look thumbnails (falling back to the document icon). **Space** previews them, **double-click / Enter** opens them in their default app, and they're skipped in the slideshow.

### Interface text size (#63)

**[def9e48](https://github.com/gsbabil/phoenix-slides/commit/def9e481d4f1efaa158239cec5387d0ad59e6001)**, **[6f7ff34](https://github.com/gsbabil/phoenix-slides/commit/6f7ff34b93f9dd46598f7066243dbbbd3edf98f9)**, **[b71dfd0](https://github.com/gsbabil/phoenix-slides/commit/b71dfd0a21f96fea5a4f6f5de9e2c7342bd2b3eb)**

- Small / Medium / Large preference scaling thumbnail labels, the directory browser, slideshow info/help, status and file-info lines, and the EXIF panel live (also fixes low-contrast slideshow text in Dark Mode).
- A **Custom** option adds a point-size field + stepper (10–25 pt) feeding the same proportional scale (`pt / systemFontSize`), so it stays app-wide rather than per-element — a superset of @webcoyote's #86. (See the **Custom** screenshot below.)

### Thumbnails & tooltips

**[1d4426f](https://github.com/gsbabil/phoenix-slides/commit/1d4426f89512f4de5bfadd1ef937c672245b5036)**, **[7f5d0db](https://github.com/gsbabil/phoenix-slides/commit/7f5d0dbfaf61d1ecd86dd81ca484881cd9d14cca)**, **[6373fec](https://github.com/gsbabil/phoenix-slides/commit/6373fec857c47328f1095bfdb40ce7b45c5ab5ec)**

- **Maximum Thumbnail Width** now scales the current size proportionally instead of only raising the cap. Hovering a thumbnail immediately shows its full filename in a lightweight popup, without the system hover delay.

### Go to Folder

**[93f398b](https://github.com/gsbabil/phoenix-slides/commit/93f398b9d4d7ee2ff6b3f07ffe9c0b43ba6902f5)**

- Finder-style **File → "Go to Folder…"** (⌘⇧G): a title-bar sheet with a `~`-expanding path field and a live list of matching sub-folders (case-insensitive; a trailing slash lists contents). **↑/↓** move the list, **→/Tab** drill in, **Enter** navigates, **Esc** cancels; a leading dot reveals hidden folders. Navigates the frontmost window.

### Path bar & directory browser

**[5fabcf6](https://github.com/gsbabil/phoenix-slides/commit/5fabcf60badf9d0233752c5f4c871219c450c1ce)**

- **View → Show/Hide Directory Browser** (⌥⌘B) and **Show/Hide Path Bar** (⌥⌘P). The path bar is a native `NSPathControl` above the file-info row: click a segment to jump there, Shift-click to pop up its sub-folders. Hiding the browser gives a full-height grid and remembers its size (and collapsed state across launches). The three view-visibility items now use the standard Show ⇄ Hide verb-swap title instead of a checkmark, matching Finder.

### About panel

**[a89d746](https://github.com/gsbabil/phoenix-slides/commit/a89d746c2d9d6a43a8ff9a19c6263890cc08ac27)**, **[a0daab7](https://github.com/gsbabil/phoenix-slides/commit/a0daab7109e858be3a9ef9f7e1ddbfd6bd5a064a)**

- The version line shows the short git commit hash (e.g. **1.6.2 (35 · 5fabcf6)**); credits use the system font.

### Documentation

**[54a6bf9](https://github.com/gsbabil/phoenix-slides/commit/54a6bf96a467e17e76c5bf17551b0f09c6c21ff3)**

- Expands the build instructions with command-line build/run/test examples and signed/notarised DMG steps.

### Copy as Pathname

**[6a21f1c](https://github.com/gsbabil/phoenix-slides/commit/6a21f1c856e10da905ff9667ed2da2355cb9f623)**

- Adds **Copy as Pathname** to the thumbnail context menu and the File menu (⌥⌘C, configurable through the keybinding config), copying the selected file path(s) to the clipboard.
- A General preference picks the style: **shell-quoted** (default — safe for spaces/special characters) or **Finder-style** raw paths, one per line.

### Open Recent (#60)

**[6140537](https://github.com/gsbabil/phoenix-slides/commit/61405373ae9f1ac33ffca00deccb0e7bf2241016)**

- Adds **File → Open Recent**, listing the last **N** folders you visited (N configurable in Preferences,
default 10).
- Each entry restores that folder's **full view state** — focused thumbnail, sort order, Subfolders, Show
Unsupported, Show File Names, Auto-Rotate, directory-browser & path-bar visibility, and thumbnail zoom. Entries
update live and persist across launches, most-recent-first.
- Missing folders are greyed out; the submenu ends with **Remove Invalid** and **Clear Menu** (or "No Recent
Folders" when empty). Clicking an entry navigates the front window, opening one if none.
 
### Filename filter (#21, #58)

**[71e0f5f](https://github.com/gsbabil/phoenix-slides/commit/71e0f5f18bbee2a1d2ae43d797c30d65d71a43dc)**

- Adds a **search field** to the browser control strip that filters the displayed thumbnails by filename as you
type — case-insensitive substring, or a **regular expression** via the magnifier menu's "Regular Expression"
toggle (checkmarked when on).
- Clearing the field or navigating to another folder restores the full listing; slideshow and Quick Look
operate on just the matches.

### ZIP archive browsing (#19)

**[b3d6bb6](https://github.com/gsbabil/phoenix-slides/commit/b3d6bb6efd58e97d5b52c48e5cb9eb6617d7ab55)**

- Open a `.zip`/`.cbz` (double-click, drag, Finder open, or **Open Recent**) to browse the images inside as if it were a folder. Archives show in the grid with their icon; starting a slideshow on one enters it. Nested archives work too.
- Extraction runs in the background (`ditto`) into a private temp folder, so it opens instantly and images stream in as they extract. Normal folder browsing is untouched — archives are only extracted on an explicit open.
- Paths shown (path bar, title, file-info, browser) treat each archive as a folder — never the raw temp path — and collapse to fit like Finder. Read-only and self-cleaning: temp files are removed on leaving, closing, or quitting, and crash leftovers are swept at launch.

## Testing

Builds clean:

```sh
xcodebuild \
  -project creevey.xcodeproj \
  -scheme "Phoenix Slides" \
  -configuration Debug build CODE_SIGNING_ALLOWED=NO
```

Manually tested: rename (cancel + selection), permanent delete, Quick Look + navigation sync + slideshow shortcuts, live text-size changes, thumbnail width scaling, hover tooltips, and editing/reloading the keybindings config.

## Notes

Commits are ordered, self-contained, and build independently. The keybindings file uses JSONC (comments stripped before parsing); a template is generated on first launch and legacy `.json` files are migrated automatically.

## Screenshots

<img width="1136" height="1293" src="https://github.com/user-attachments/assets/9de740fa-d36f-45c9-94b5-72a4724ca289" /><img width="1136" height="1293" src="https://github.com/user-attachments/assets/9de740fa-d36f-45c9-94b5-72a4724ca289" />
<img width="1024" height="1182" src="https://github.com/user-attachments/assets/150848a7-b6c0-41f4-ae7b-c54d6552efd9" />
<img width="1024" height="1182" src="https://github.com/user-attachments/assets/ebff745f-158d-4c8d-a84a-ecfbf826cea5" />
<img width="1024" height="1182" src="https://github.com/user-attachments/assets/d6df885e-d6fb-492c-89c8-770f6fa5a2e4" />
<img width="253" height="379" src="https://github.com/user-attachments/assets/4a11e66e-071b-48c3-a2b3-e838f7e11cfa" />
<img width="505" height="645" src="https://github.com/user-attachments/assets/c3849581-fa62-4df8-a396-4b75513b2303" />
<img width="1136" height="1294" src="https://github.com/user-attachments/assets/f634ae73-248e-47c3-ba66-67f6e6f73ebf" />
<img width="1020" height="1214" src="https://github.com/user-attachments/assets/40bdc3a6-50bd-4512-8e5c-ddde5ff8c459" />
<img width="1025" height="623" src="https://github.com/user-attachments/assets/ab933feb-db2a-4282-91a9-f3f150e7c205" />
<img width="1136" height="703" src="https://github.com/user-attachments/assets/792f0234-695a-4cfb-a630-b8cbed9fef73" />
<img width="607" height="561" src="https://github.com/user-attachments/assets/438e0a94-97e9-4a96-8d4b-225cbe93dd19" />
<img width="290" height="346" src="https://github.com/user-attachments/assets/21bc837d-bd94-4c10-b90f-7b87adcd0671" />
<img width="932" height="607" src="https://github.com/user-attachments/assets/ff7e6754-a7ba-4761-8b9b-75d70c4d9731" />
<img width="1023" height="622" alt="image" src="https://github.com/user-attachments/assets/b0055366-fd06-4a95-968f-47a95f709c4e" />
<img width="1025" height="592" alt="image" src="https://github.com/user-attachments/assets/5bb4656b-b4f8-4284-ada9-eb6af0b7205d" />
<img width="1024" height="587" alt="image" src="https://github.com/user-attachments/assets/5e4bad0f-0558-4e35-80a6-59835e8fdd2c" />


